### PR TITLE
feat: reticle selector in sight wizard

### DIFF
--- a/lib/features/home/sub_screens/home_sub_screens.dart
+++ b/lib/features/home/sub_screens/home_sub_screens.dart
@@ -10,3 +10,4 @@ export 'powder_sens_table_editor_screen.dart';
 export 'sight_collection_screen.dart';
 export 'weapon_collection_screen.dart';
 export 'ammo_collection_screen.dart';
+export 'reticle_picker_screen.dart';

--- a/lib/features/home/sub_screens/reticle_picker_screen.dart
+++ b/lib/features/home/sub_screens/reticle_picker_screen.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:ebalistyka/core/providers/reticle_provider.dart';
+import 'package:ebalistyka/shared/widgets/base_screen.dart';
+
+class ReticlePickerScreen extends ConsumerWidget {
+  const ReticlePickerScreen({this.currentReticleId, super.key});
+
+  final String? currentReticleId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final listAsync = ref.watch(reticleListProvider);
+
+    return BaseScreen(
+      title: 'Select Reticle',
+      isSubscreen: true,
+      body: listAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (ids) => ListView.builder(
+          itemCount: ids.length,
+          itemBuilder: (context, i) => _ReticleTile(
+            reticleId: ids[i],
+            isSelected: ids[i] == (currentReticleId ?? defaultReticleId),
+            onTap: () => context.pop(ids[i]),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ReticleTile extends ConsumerWidget {
+  const _ReticleTile({
+    required this.reticleId,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final String reticleId;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final svgAsync = ref.watch(reticleSvgProvider(reticleId));
+    final cs = Theme.of(context).colorScheme;
+
+    return ListTile(
+      onTap: onTap,
+      selected: isSelected,
+      leading: SizedBox(
+        width: 48,
+        height: 48,
+        child: svgAsync.when(
+          loading: () => const SizedBox.shrink(),
+          error: (_, __) => const SizedBox.shrink(),
+          data: (svg) => ClipOval(
+            child: SvgPicture.string(
+              _resolveColors(svg, cs),
+              fit: BoxFit.contain,
+            ),
+          ),
+        ),
+      ),
+      title: Text(reticleId),
+      trailing: isSelected ? Icon(Icons.check, color: cs.primary) : null,
+    );
+  }
+
+  static String _resolveColors(String svg, ColorScheme cs) {
+    final roles = {
+      'onSurface': cs.onSurface,
+      'onBackground': cs.onSurface,
+      'primary': cs.primary,
+      'secondary': cs.secondary,
+      'error': cs.error,
+    };
+    var result = svg;
+    for (final e in roles.entries) {
+      result = result.replaceAll('"${e.key}"', '"${_hex(e.value)}"');
+    }
+    return result;
+  }
+
+  static String _hex(Color c) {
+    final v = c.toARGB32();
+    return '#${(v & 0xFFFFFF).toRadixString(16).padLeft(6, '0')}';
+  }
+}

--- a/lib/features/home/sub_screens/sight_wizard_screen.dart
+++ b/lib/features/home/sub_screens/sight_wizard_screen.dart
@@ -13,6 +13,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:ebalistyka/router.dart';
+
 class SightWizardScreen extends ConsumerStatefulWidget {
   const SightWizardScreen({this.initial, super.key});
 
@@ -45,6 +47,8 @@ class _SightWizardScreenState extends ConsumerState<SightWizardScreen> {
   // magnification: dimensionless scalar (FC.magnification, Unit.scalar)
   late double _minMagRaw;
   late double _maxMagRaw;
+
+  late String? _reticleImage;
 
   static const _clickUnits = [
     Unit.mil,
@@ -81,6 +85,8 @@ class _SightWizardScreenState extends ConsumerState<SightWizardScreen> {
     final storedMax = s?.maxMagnification ?? 0.0;
     _minMagRaw = storedMin > 0 ? storedMin : 1.0;
     _maxMagRaw = storedMax > 0 ? storedMax : 1.0;
+
+    _reticleImage = s?.reticleImage;
   }
 
   @override
@@ -127,6 +133,7 @@ class _SightWizardScreenState extends ConsumerState<SightWizardScreen> {
     ).in_(_hClickUnit);
     sight.minMagnification = _minMagRaw;
     sight.maxMagnification = _maxMagRaw;
+    sight.reticleImage = _reticleImage;
     return sight;
   }
 
@@ -207,6 +214,25 @@ class _SightWizardScreenState extends ConsumerState<SightWizardScreen> {
           // ── Reticle ────────────────────────────────────────────────
           const Divider(height: 1),
           const ListSectionTile('Reticle'),
+          ListTile(
+            leading: const Icon(IconDef.sight),
+            title: const Text('Reticle pattern'),
+            subtitle: Text(_reticleImage ?? 'default'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () async {
+              final route = widget.initial != null
+                  ? Routes.sightEditReticlePicker
+                  : Routes.sightCreateReticlePicker;
+              final result = await context.push<String?>(
+                route,
+                extra: _reticleImage,
+              );
+              if (result != null && mounted) {
+                setState(() => _reticleImage = result);
+              }
+            },
+          ),
+          const Divider(height: 1),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
             child: SegmentedButton<FocalPlane>(

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -50,11 +50,15 @@ abstract final class Routes {
   static const sightSelect = '/home/profiles/sight-select';
   static const sightCreate = '/home/profiles/sight-select/create';
   static const sightCollection = '/home/profiles/sight-select/collection';
+  static const sightCreateReticlePicker =
+      '/home/profiles/sight-select/create/reticle-picker';
 
   // Profile inline edits (from profile card)
   static const profileEditWeapon = '/home/profiles/weapon-edit';
   static const profileEditAmmo = '/home/profiles/ammo-edit';
   static const profileEditSight = '/home/profiles/sight-edit';
+  static const sightEditReticlePicker =
+      '/home/profiles/sight-edit/reticle-picker';
 
   // Ammo wizard sub-screens
   static const ammoEditMultiBcG1 = '/home/profiles/ammo-edit/multi-bc-g1';
@@ -148,6 +152,14 @@ final appRouter = GoRouter(
                         GoRoute(
                           path: 'create',
                           builder: (_, _) => const SightWizardScreen(),
+                          routes: [
+                            GoRoute(
+                              path: 'reticle-picker',
+                              builder: (_, state) => ReticlePickerScreen(
+                                currentReticleId: state.extra as String?,
+                              ),
+                            ),
+                          ],
                         ),
                         GoRoute(
                           path: 'collection',
@@ -239,6 +251,14 @@ final appRouter = GoRouter(
                       path: 'sight-edit',
                       builder: (_, state) =>
                           SightWizardScreen(initial: state.extra as Sight?),
+                      routes: [
+                        GoRoute(
+                          path: 'reticle-picker',
+                          builder: (_, state) => ReticlePickerScreen(
+                            currentReticleId: state.extra as String?,
+                          ),
+                        ),
+                      ],
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Summary

- Add `ReticlePickerScreen` — scrollable list of all reticles from `assets/reticles/`, each shown as a `ListTile` with 48×48 SVG thumbnail and ID label
- `SightWizardScreen`: new "Reticle pattern" tile in the Reticle section opens the picker; selected ID is saved to `sight.reticleImage` on Save
- Router: `sightCreateReticlePicker` and `sightEditReticlePicker` routes wired as sub-routes of the create/edit sight wizard

## Behaviour

- Thumbnails use the same runtime color substitution (`onSurface`, `primary`, etc.) as the home reticle view
- Currently selected reticle is highlighted with a checkmark
- Falls back to `"default"` label when `reticleImage` is `null`
- Saving the wizard persists `reticleImage` via ObjectBox → `homeVmProvider` and `_ReticleView` update reactively

## Test plan

- [ ] Open sight wizard (create or edit)
- [ ] Tap "Reticle pattern" tile → picker screen opens with all available reticles listed
- [ ] Tap a reticle → returns to wizard, subtitle updates to selected ID
- [ ] Save → reticle view on Home screen switches to the selected reticle
- [ ] Verify edit mode pre-selects the current reticle (checkmark in picker)

https://claude.ai/code/session_018gZjp1Y5sc3dPn5rNyCPB5