### PR TITLE
build(android): always build all 4 APKs — split per-ABI + universal fat

### DIFF
--- a/.github/workflows/build-aab.yml
+++ b/.github/workflows/build-aab.yml
@@ -1,0 +1,188 @@
+name: Build Android AAB
+
+on:
+  workflow_call:
+    inputs:
+      build_name:
+        description: "Version name (e.g. v1.2.3)"
+        required: false
+        type: string
+        default: ""
+      build_type:
+        description: "Build type"
+        required: false
+        type: string
+        default: "release"
+      retention_days:
+        description: "Artifact retention in days"
+        required: false
+        type: number
+        default: 30
+    secrets:
+      ANDROID_KEYSTORE_BASE64:
+        description: "Base64-encoded Android keystore (.jks / .p12)"
+        required: false
+      ANDROID_KEYSTORE_PASSWORD:
+        description: "Keystore store password"
+        required: false
+      ANDROID_KEY_ALIAS:
+        description: "Key alias inside the keystore"
+        required: false
+      ANDROID_KEY_PASSWORD:
+        description: "Key password"
+        required: false
+    outputs:
+      artifact_name:
+        description: "Name of the uploaded artifact"
+        value: ${{ jobs.build.outputs.artifact_name }}
+      artifact_url:
+        description: "URL to the artifact"
+        value: ${{ jobs.build.outputs.artifact_url }}
+
+  workflow_dispatch:
+    inputs:
+      build_name:
+        description: "Version name override (leave empty to use pubspec.yaml)"
+        required: false
+        default: ""
+        type: string
+      build_type:
+        description: "Build type"
+        required: false
+        default: "release"
+        type: choice
+        options: [ release, debug ]
+
+env:
+  FLUTTER_VERSION: "3.41.6"
+
+concurrency:
+  group: build-aab-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare-version:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_call'
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: v
+        uses: ./.github/actions/version
+
+  build:
+    needs: [ prepare-version ]
+    if: always()
+    name: Android AAB (${{ inputs.build_type || 'release' }})
+    runs-on: ubuntu-latest
+    outputs:
+      artifact_name: ${{ steps.meta.outputs.artifact_name }}
+      artifact_url:  ${{ steps.upload.outputs.artifact-url }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Flutter
+        uses: ./.github/actions/flutter
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
+
+      - name: Accept Android licenses
+        run: yes | flutter doctor --android-licenses || true
+
+      - name: Set build metadata
+        id: meta
+        shell: bash
+        run: |
+          BUILD_NAME="${{ inputs.build_name || needs.prepare-version.outputs.version }}"
+          BUILD_NAME="${BUILD_NAME#v}"
+          BUILD_NUMBER=$(git rev-list --count --first-parent HEAD)
+          BCLIBC_HASH=$(git -C external/bclibc rev-parse HEAD)
+          BCLIBC_FFI_HASH=$(git log -1 --format='%H' -- packages/bclibc_ffi 2>/dev/null || echo "unknown")
+          echo "build_name=$BUILD_NAME"           >> $GITHUB_OUTPUT
+          echo "build_number=$BUILD_NUMBER"       >> $GITHUB_OUTPUT
+          echo "bclibc_hash=$BCLIBC_HASH"         >> $GITHUB_OUTPUT
+          echo "bclibc_ffi_hash=$BCLIBC_FFI_HASH" >> $GITHUB_OUTPUT
+          echo "artifact_name=ebalistyka-android-aab-${{ inputs.build_type || 'release' }}-${BUILD_NAME}-${BUILD_NUMBER}" >> $GITHUB_OUTPUT
+
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/pub-cache
+          key: pub-android-${{ hashFiles('pubspec.lock') }}
+          restore-keys: pub-android-
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('android/app/build.gradle.kts', 'android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+
+      - name: Cache bclibc NDK build
+        uses: actions/cache@v4
+        with:
+          path: packages/bclibc_ffi/android/.cxx
+          key: bclibc-android-${{ steps.meta.outputs.bclibc_hash }}-${{ steps.meta.outputs.bclibc_ffi_hash }}
+          restore-keys: |
+            bclibc-android-${{ steps.meta.outputs.bclibc_hash }}-
+            bclibc-android-
+
+      - name: Install Flutter dependencies
+        run: flutter clean
+
+      - name: Set pubspec version
+        run: |
+          BASE=$(echo "${{ steps.meta.outputs.build_name }}" | sed 's/-.*//')
+          NUM=${{ steps.meta.outputs.build_number }}
+          sed -i "s/^version:.*/version: ${BASE}+${NUM}/" pubspec.yaml
+          echo "pubspec version → ${BASE}+${NUM}"
+
+      - name: Get Flutter dependencies
+        run: flutter pub get
+
+      - name: Build & sign AAB
+        env:
+          ANDROID_KEYSTORE_BASE64:   ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS:         ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD:      ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          bash scripts/build-android-aab.sh \
+            "${{ steps.meta.outputs.build_name }}" \
+            "${{ steps.meta.outputs.build_number }}"
+
+      - name: Upload artifact
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.meta.outputs.artifact_name }}
+          path: artifacts/
+          retention-days: ${{ inputs.retention_days || 30 }}
+          if-no-files-found: error
+
+
+  pr-summary:
+    needs: [ build ]
+    if: always() && github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+      issues: write
+    uses: ./.github/workflows/pr-summary.yml
+    with:
+      platform: Android AAB
+      build_result: ${{ needs.build.result }}
+      artifact_name: ${{ needs.build.outputs.artifact_name }}
+      artifact_url: ${{ needs.build.outputs.artifact_url }}

--- a/.github/workflows/build-aab.yml
+++ b/.github/workflows/build-aab.yml
@@ -53,6 +53,17 @@ on:
         type: choice
         options: [ release, debug ]
 
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - "lib/**"
+      - "android/**"
+      - "external/**"
+      - "packages/bclibc_ffi/**"
+      - "pubspec.yaml"
+      - "scripts/build-android-aab.sh"
+      - ".github/workflows/build-aab.yml"
+
 env:
   FLUTTER_VERSION: "3.41.6"
 
@@ -172,3 +183,17 @@ jobs:
           path: artifacts/
           retention-days: ${{ inputs.retention_days || 30 }}
           if-no-files-found: error
+
+
+  pr-summary:
+    needs: [ build ]
+    if: always() && github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+      issues: write
+    uses: ./.github/workflows/pr-summary.yml
+    with:
+      platform: Android AAB
+      build_result: ${{ needs.build.result }}
+      artifact_name: ${{ needs.build.outputs.artifact_name }}
+      artifact_url: ${{ needs.build.outputs.artifact_url }}

--- a/.github/workflows/build-aab.yml
+++ b/.github/workflows/build-aab.yml
@@ -172,17 +172,3 @@ jobs:
           path: artifacts/
           retention-days: ${{ inputs.retention_days || 30 }}
           if-no-files-found: error
-
-
-  pr-summary:
-    needs: [ build ]
-    if: always() && github.event_name == 'pull_request'
-    permissions:
-      pull-requests: write
-      issues: write
-    uses: ./.github/workflows/pr-summary.yml
-    with:
-      platform: Android AAB
-      build_result: ${{ needs.build.result }}
-      artifact_name: ${{ needs.build.outputs.artifact_name }}
-      artifact_url: ${{ needs.build.outputs.artifact_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,21 @@ jobs:
       ANDROID_KEY_ALIAS:         ${{ secrets.ANDROID_KEY_ALIAS }}
       ANDROID_KEY_PASSWORD:      ${{ secrets.ANDROID_KEY_PASSWORD }}
 
+  build-android-aab:
+    needs: prepare-version
+    uses: ./.github/workflows/build-aab.yml
+    with:
+      build_name: ${{ needs.prepare-version.outputs.version }}
+      build_type: release
+      retention_days: 1
+    secrets:
+      ANDROID_KEYSTORE_BASE64:   ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEY_ALIAS:         ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_PASSWORD:      ${{ secrets.ANDROID_KEY_PASSWORD }}
+
   release:
-    needs: [prepare-version, build-linux-amd64, build-linux-arm64, build-windows-amd64, build-android]
+    needs: [prepare-version, build-linux-amd64, build-linux-arm64, build-windows-amd64, build-android, build-android-aab]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -97,7 +110,8 @@ jobs:
             -name "*.msix"        -o \
             -name "*.appinstaller" -o \
             -name "*.cer"         -o \
-            -name "*.apk" \
+            -name "*.apk"         -o \
+            -name "*.aab" \
           \) -exec cp {} release/ \;
 
           echo "=== Release assets ==="

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,9 @@ jobs:
 
   build-android-aab:
     needs: prepare-version
+    permissions:
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/build-aab.yml
     with:
       build_name: ${{ needs.prepare-version.outputs.version }}

--- a/scripts/build-android-aab.sh
+++ b/scripts/build-android-aab.sh
@@ -27,6 +27,12 @@ BUILD_NAME="${BUILD_NAME#v}"
 # Strip pre-release suffix for versionCode compatibility: "1.2.3-beta" → "1.2.3"
 BASE=$(echo "$BUILD_NAME" | sed 's/-.*//')
 
+# ── Cleanup trap ─────────────────────────────────────────────────────────────
+cleanup() {
+    rm -f android/ebalistyka.keystore android/key.properties
+}
+trap cleanup EXIT
+
 # ── Android signing ──────────────────────────────────────────────────────────
 if [ -n "${ANDROID_KEYSTORE_BASE64:-}" ]; then
     echo "Setting up Android release signing…"

--- a/scripts/build-android-aab.sh
+++ b/scripts/build-android-aab.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Build Flutter Android App Bundle (AAB) and place it in artifacts/.
+#
+# Usage:
+#   build-android-aab.sh <build_name> <build_number>
+#
+# Arguments:
+#   build_name    Version string, e.g. "1.2.3" or "v1.2.3-beta".  "v" prefix is stripped.
+#   build_number  Integer build number (git rev-list --count --first-parent HEAD — monotonically increasing).
+#
+# Signing (optional — falls back to debug key if not set):
+#   ANDROID_KEYSTORE_BASE64      Base64-encoded .jks/.p12 keystore file.
+#   ANDROID_KEYSTORE_PASSWORD    Keystore (store) password.
+#   ANDROID_KEY_ALIAS            Key alias inside the keystore.
+#   ANDROID_KEY_PASSWORD         Key password.
+#
+# Outputs:
+#   artifacts/ebalistyka_android.aab
+
+set -euo pipefail
+
+BUILD_NAME="${1:-0.1.0-dev}"
+BUILD_NUMBER="${2:-0}"
+
+# Strip leading 'v'
+BUILD_NAME="${BUILD_NAME#v}"
+# Strip pre-release suffix for versionCode compatibility: "1.2.3-beta" → "1.2.3"
+BASE=$(echo "$BUILD_NAME" | sed 's/-.*//')
+
+# ── Android signing ──────────────────────────────────────────────────────────
+if [ -n "${ANDROID_KEYSTORE_BASE64:-}" ]; then
+    echo "Setting up Android release signing…"
+    echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > android/ebalistyka.keystore
+    cat > android/key.properties <<EOF
+storePassword=${ANDROID_KEYSTORE_PASSWORD}
+keyPassword=${ANDROID_KEY_PASSWORD}
+keyAlias=${ANDROID_KEY_ALIAS}
+storeFile=../ebalistyka.keystore
+EOF
+    echo "Keystore written → android/ebalistyka.keystore  (alias: ${ANDROID_KEY_ALIAS})"
+else
+    echo "ANDROID_KEYSTORE_BASE64 not set — using debug signing"
+fi
+
+# ── Build AAB ────────────────────────────────────────────────────────────────
+flutter build appbundle --release \
+  --build-name="$BASE" \
+  --build-number="$BUILD_NUMBER"
+
+# ── Package ──────────────────────────────────────────────────────────────────
+mkdir -p artifacts
+
+cp build/app/outputs/bundle/release/app-release.aab artifacts/ebalistyka_android.aab
+
+echo "=== AAB artifacts ==="
+ls -lh artifacts/

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-# Build Flutter Android APKs and place them in artifacts/.
+# Build Flutter Android APKs (per-ABI split + universal fat) and place them in artifacts/.
 #
 # Usage:
-#   build-android.sh <build_name> <build_number> [--fat]
+#   build-android.sh <build_name> <build_number>
 #
 # Arguments:
 #   build_name    Version string, e.g. "1.2.3" or "v1.2.3-beta".  "v" prefix is stripped.
 #   build_number  Integer build number (git rev-list --count --first-parent HEAD — monotonically increasing).
-#   --fat         Build a single fat APK instead of per-ABI split (optional).
 #
 # Signing (optional — falls back to debug key if not set):
 #   ANDROID_KEYSTORE_BASE64      Base64-encoded .jks/.p12 keystore file.
@@ -19,14 +18,12 @@
 #   artifacts/ebalistyka_android_arm64.apk
 #   artifacts/ebalistyka_android_armeabi_v7a.apk
 #   artifacts/ebalistyka_android_x86_64.apk
-#   — or —
-#   artifacts/ebalistyka_android.apk          (when --fat)
+#   artifacts/ebalistyka_android_universal.apk
 
 set -euo pipefail
 
 BUILD_NAME="${1:-0.1.0-dev}"
 BUILD_NUMBER="${2:-0}"
-FAT="${3:-}"
 
 # Strip leading 'v'
 BUILD_NAME="${BUILD_NAME#v}"
@@ -48,28 +45,23 @@ else
     echo "ANDROID_KEYSTORE_BASE64 not set — using debug signing"
 fi
 
-# ── Build ────────────────────────────────────────────────────────────────────
-if [ "$FAT" = "--fat" ]; then
-    flutter build apk --release \
-      --build-name="$BASE" \
-      --build-number="$BUILD_NUMBER"
-else
-    flutter build apk --release --split-per-abi \
-      --build-name="$BASE" \
-      --build-number="$BUILD_NUMBER"
-fi
+# ── Build per-ABI split APKs ─────────────────────────────────────────────────
+flutter build apk --release --split-per-abi \
+  --build-name="$BASE" \
+  --build-number="$BUILD_NUMBER"
+
+# ── Build universal (fat) APK ────────────────────────────────────────────────
+flutter build apk --release \
+  --build-name="$BASE" \
+  --build-number="$BUILD_NUMBER"
 
 # ── Package ──────────────────────────────────────────────────────────────────
 mkdir -p artifacts
 
-if [ "$FAT" = "--fat" ]; then
-    cp build/app/outputs/flutter-apk/app-release.apk \
-       artifacts/ebalistyka_android.apk
-else
-    cp build/app/outputs/flutter-apk/app-arm64-v8a-release.apk   artifacts/ebalistyka_android_arm64.apk
-    cp build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk artifacts/ebalistyka_android_armeabi_v7a.apk
-    cp build/app/outputs/flutter-apk/app-x86_64-release.apk      artifacts/ebalistyka_android_x86_64.apk
-fi
+cp build/app/outputs/flutter-apk/app-arm64-v8a-release.apk   artifacts/ebalistyka_android_arm64.apk
+cp build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk artifacts/ebalistyka_android_armeabi_v7a.apk
+cp build/app/outputs/flutter-apk/app-x86_64-release.apk      artifacts/ebalistyka_android_x86_64.apk
+cp build/app/outputs/flutter-apk/app-release.apk              artifacts/ebalistyka_android_universal.apk
 
 echo "=== APK artifacts ==="
 ls -lh artifacts/

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -30,6 +30,12 @@ BUILD_NAME="${BUILD_NAME#v}"
 # Strip pre-release suffix for versionCode compatibility: "1.2.3-beta" → "1.2.3"
 BASE=$(echo "$BUILD_NAME" | sed 's/-.*//')
 
+# ── Cleanup trap ─────────────────────────────────────────────────────────────
+cleanup() {
+    rm -f android/ebalistyka.keystore android/key.properties
+}
+trap cleanup EXIT
+
 # ── Android signing ──────────────────────────────────────────────────────────
 if [ -n "${ANDROID_KEYSTORE_BASE64:-}" ]; then
     echo "Setting up Android release signing…"
@@ -50,18 +56,19 @@ flutter build apk --release --split-per-abi \
   --build-name="$BASE" \
   --build-number="$BUILD_NUMBER"
 
+# Copy split APKs immediately — Gradle stale-output cleanup in the next build
+# may remove files produced by a differently-configured assembleRelease run.
+mkdir -p artifacts
+cp build/app/outputs/flutter-apk/app-arm64-v8a-release.apk   artifacts/ebalistyka_android_arm64.apk
+cp build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk artifacts/ebalistyka_android_armeabi_v7a.apk
+cp build/app/outputs/flutter-apk/app-x86_64-release.apk      artifacts/ebalistyka_android_x86_64.apk
+
 # ── Build universal (fat) APK ────────────────────────────────────────────────
 flutter build apk --release \
   --build-name="$BASE" \
   --build-number="$BUILD_NUMBER"
 
-# ── Package ──────────────────────────────────────────────────────────────────
-mkdir -p artifacts
-
-cp build/app/outputs/flutter-apk/app-arm64-v8a-release.apk   artifacts/ebalistyka_android_arm64.apk
-cp build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk artifacts/ebalistyka_android_armeabi_v7a.apk
-cp build/app/outputs/flutter-apk/app-x86_64-release.apk      artifacts/ebalistyka_android_x86_64.apk
-cp build/app/outputs/flutter-apk/app-release.apk              artifacts/ebalistyka_android_universal.apk
+cp build/app/outputs/flutter-apk/app-release.apk artifacts/ebalistyka_android_universal.apk
 
 echo "=== APK artifacts ==="
 ls -lh artifacts/


### PR DESCRIPTION
Removes the --fat flag and always produces both builds:
- per-ABI split: arm64, armeabi-v7a, x86_64
- fat renamed to ebalistyka_android_universal.apk

https://claude.ai/code/session_01UV6BGg9BP8TdWJZxuHcwk3