### PR TITLE
feat(flatpak): bump GNOME runtime to 49, cache CI runtimes, sync flat…

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -115,13 +115,19 @@ jobs:
           mkdir -p bundle
           tar -xzf "dl/portable/ebalistyka_linux_${ARCH_SUFFIX}.tar.gz" -C bundle/
 
+      - name: Cache Flatpak runtimes
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/flatpak
+          key: flatpak-gnome-49-${{ runner.arch }}
+
       - name: Install flatpak tools
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y flatpak flatpak-builder
-          sudo flatpak remote-add --system --if-not-exists flathub \
+          flatpak remote-add --user --if-not-exists flathub \
             https://flathub.org/repo/flathub.flatpakrepo
-          sudo flatpak install --system -y --noninteractive flathub \
+          flatpak install --user -y --noninteractive flathub \
             org.gnome.Platform//49 org.gnome.Sdk//49
 
       - name: Package Flatpak

--- a/flatpak/io.github.o_murphy.ebalistyka.flathub.yml
+++ b/flatpak/io.github.o_murphy.ebalistyka.flathub.yml
@@ -1,6 +1,6 @@
 app-id: io.github.o_murphy.ebalistyka
 runtime: org.gnome.Platform
-runtime-version: '48'
+runtime-version: '49'
 sdk: org.gnome.Sdk
 command: ebalistyka
 

--- a/scripts/package-flatpak.sh
+++ b/scripts/package-flatpak.sh
@@ -5,11 +5,11 @@
 #   bundle_dir   — path to the extracted Flutter Linux bundle
 #   arch_suffix  — x86_64 | aarch64
 #
-# Requirements: flatpak, flatpak-builder, org.gnome.Platform//48 runtime.
+# Requirements: flatpak, flatpak-builder, org.gnome.Platform//49 runtime.
 # Local setup:
 #   sudo apt install flatpak flatpak-builder
 #   flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-#   flatpak install --user flathub org.gnome.Platform//48 org.gnome.Sdk//48
+#   flatpak install --user flathub org.gnome.Platform//49 org.gnome.Sdk//49
 set -euo pipefail
 
 BUNDLE_DIR="${1:?Usage: package-flatpak.sh <bundle_dir> <arch_suffix>}"
@@ -52,7 +52,7 @@ sed -i "s|<release version=\"[^\"]*\" date=\"[^\"]*\"/>|<release version=\"${BUI
 
 echo "✓ Bundle prepared (version: ${BUILD_NAME})"
 
-# ── Build ─────────────────────────────────────────────────────────────────────
+# ── Build ───────────────────────────────────────────────────────────────────
 REPO_DIR=".flatpak-repo"
 BUILD_DIR=".flatpak-build"
 


### PR DESCRIPTION
…hub template

- Bump org.gnome.Platform/Sdk from 48 to 49 in local and flathub template manifests (GNOME 48 is end-of-life since March 24, 2026)
- Remove zenity workarounds: file_picker 11.x uses XDG portal exclusively
- Cache ~/.local/share/flatpak in CI via actions/cache to avoid re-downloading ~700 MB of org.gnome.Platform//49 + Sdk on every run (--user install)