### PR TITLE
Refactor Linux build workflows to use reusable workflow pattern

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,16 +1,6 @@
 name: Build AppImage
 
 on:
-  pull_request:
-    branches: [ main, develop ]
-    paths:
-      - "lib/**"
-      - "linux/**"
-      - "external/**"
-      - "packages/bclibc_ffi/**"
-      - "pubspec.yaml"
-      - ".github/workflows/build-appimage.yml"
-      - ".github/workflows/build.yml"
   workflow_call:
     inputs:
       arch:

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,6 +1,16 @@
 name: Build AppImage
 
 on:
+  # pull_request:
+  #   branches: [ main, develop ]
+  #   paths:
+  #     - "lib/**"
+  #     - "linux/**"
+  #     - "external/**"
+  #     - "packages/bclibc_ffi/**"
+  #     - "pubspec.yaml"
+  #     - ".github/workflows/build-appimage.yml"
+  #     - ".github/workflows/build.yml"
   workflow_call:
     inputs:
       arch:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,6 +1,19 @@
 name: Build deb
 
 on:
+  # pull_request:
+  #   branches: [ main, develop ]
+  #   paths:
+  #     - "lib/**"
+  #     - "linux/**"
+  #     - "external/**"
+  #     - "packages/bclibc_ffi/**"
+  #     - "pubspec.yaml"
+  #     - "deb/**"
+  #     - "flatpak/*.desktop"
+  #     - "flatpak/*.metainfo.xml"
+  #     - ".github/workflows/build-deb.yml"
+  #     - ".github/workflows/build.yml"
   workflow_call:
     inputs:
       arch:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,19 +1,6 @@
 name: Build deb
 
 on:
-  pull_request:
-    branches: [ main, develop ]
-    paths:
-      - "lib/**"
-      - "linux/**"
-      - "external/**"
-      - "packages/bclibc_ffi/**"
-      - "pubspec.yaml"
-      - "deb/**"
-      - "flatpak/*.desktop"
-      - "flatpak/*.metainfo.xml"
-      - ".github/workflows/build-deb.yml"
-      - ".github/workflows/build.yml"
   workflow_call:
     inputs:
       arch:

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,17 +1,6 @@
 name: Build Flatpak
 
 on:
-  pull_request:
-    branches: [ main, develop ]
-    paths:
-      - "lib/**"
-      - "linux/**"
-      - "external/**"
-      - "packages/bclibc_ffi/**"
-      - "pubspec.yaml"
-      - "flatpak/**"
-      - ".github/workflows/build-flatpak.yml"
-      - ".github/workflows/build.yml"
   workflow_call:
     inputs:
       arch:

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,6 +1,17 @@
 name: Build Flatpak
 
 on:
+  # pull_request:
+  #   branches: [ main, develop ]
+  #   paths:
+  #     - "lib/**"
+  #     - "linux/**"
+  #     - "external/**"
+  #     - "packages/bclibc_ffi/**"
+  #     - "pubspec.yaml"
+  #     - "flatpak/**"
+  #     - ".github/workflows/build-flatpak.yml"
+  #     - ".github/workflows/build.yml"
   workflow_call:
     inputs:
       arch:

--- a/.github/workflows/build-portable.yml
+++ b/.github/workflows/build-portable.yml
@@ -1,16 +1,6 @@
 name: Build Linux Portable
 
 on:
-  pull_request:
-    branches: [ main, develop ]
-    paths:
-      - "lib/**"
-      - "linux/**"
-      - "external/**"
-      - "packages/bclibc_ffi/**"
-      - "pubspec.yaml"
-      - ".github/workflows/build-portable.yml"
-      - ".github/workflows/build.yml"
   workflow_call:
     inputs:
       arch:

--- a/.github/workflows/build-portable.yml
+++ b/.github/workflows/build-portable.yml
@@ -1,6 +1,16 @@
 name: Build Linux Portable
 
 on:
+  # pull_request:
+  #   branches: [ main, develop ]
+  #   paths:
+  #     - "lib/**"
+  #     - "linux/**"
+  #     - "external/**"
+  #     - "packages/bclibc_ffi/**"
+  #     - "pubspec.yaml"
+  #     - ".github/workflows/build-portable.yml"
+  #     - ".github/workflows/build.yml"
   workflow_call:
     inputs:
       arch:

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -1,19 +1,6 @@
 name: Build rpm
 
 on:
-  pull_request:
-    branches: [ main, develop ]
-    paths:
-      - "lib/**"
-      - "linux/**"
-      - "external/**"
-      - "packages/bclibc_ffi/**"
-      - "pubspec.yaml"
-      - "rpm/**"
-      - "flatpak/*.desktop"
-      - "flatpak/*.metainfo.xml"
-      - ".github/workflows/build-rpm.yml"
-      - ".github/workflows/build.yml"
   workflow_call:
     inputs:
       arch:

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -1,6 +1,19 @@
 name: Build rpm
 
 on:
+  # pull_request:
+  #   branches: [ main, develop ]
+  #   paths:
+  #     - "lib/**"
+  #     - "linux/**"
+  #     - "external/**"
+  #     - "packages/bclibc_ffi/**"
+  #     - "pubspec.yaml"
+  #     - "rpm/**"
+  #     - "flatpak/*.desktop"
+  #     - "flatpak/*.metainfo.xml"
+  #     - ".github/workflows/build-rpm.yml"
+  #     - ".github/workflows/build.yml"
   workflow_call:
     inputs:
       arch:

--- a/.github/workflows/pr-linux.yml
+++ b/.github/workflows/pr-linux.yml
@@ -2,7 +2,6 @@ name: PR Linux Builds
 
 on:
   pull_request:
-    branches: [ main, develop ]
     paths:
       - "lib/**"
       - "linux/**"

--- a/.github/workflows/pr-linux.yml
+++ b/.github/workflows/pr-linux.yml
@@ -1,0 +1,79 @@
+name: PR Linux Builds
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - "lib/**"
+      - "linux/**"
+      - "external/**"
+      - "packages/bclibc_ffi/**"
+      - "pubspec.yaml"
+      - "deb/**"
+      - "rpm/**"
+      - "flatpak/**"
+      - ".github/workflows/pr-linux.yml"
+      - ".github/workflows/build.yml"
+      - ".github/workflows/build-portable.yml"
+      - ".github/workflows/build-appimage.yml"
+      - ".github/workflows/build-deb.yml"
+      - ".github/workflows/build-rpm.yml"
+      - ".github/workflows/build-flatpak.yml"
+
+concurrency:
+  group: pr-linux-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-bundle:
+    permissions:
+      pull-requests: write
+      issues: write
+    uses: ./.github/workflows/build-portable.yml
+    with:
+      arch: amd64
+      retention_days: 1
+
+  build-appimage:
+    needs: build-bundle
+    permissions:
+      pull-requests: write
+      issues: write
+    uses: ./.github/workflows/build-appimage.yml
+    with:
+      arch: amd64
+      retention_days: 1
+      bundle_artifact_name: ${{ needs.build-bundle.outputs.artifact_name }}
+
+  build-deb:
+    needs: build-bundle
+    permissions:
+      pull-requests: write
+      issues: write
+    uses: ./.github/workflows/build-deb.yml
+    with:
+      arch: amd64
+      retention_days: 1
+      bundle_artifact_name: ${{ needs.build-bundle.outputs.artifact_name }}
+
+  build-rpm:
+    needs: build-bundle
+    permissions:
+      pull-requests: write
+      issues: write
+    uses: ./.github/workflows/build-rpm.yml
+    with:
+      arch: amd64
+      retention_days: 1
+      bundle_artifact_name: ${{ needs.build-bundle.outputs.artifact_name }}
+
+  build-flatpak:
+    needs: build-bundle
+    permissions:
+      pull-requests: write
+      issues: write
+    uses: ./.github/workflows/build-flatpak.yml
+    with:
+      arch: amd64
+      retention_days: 1
+      bundle_artifact_name: ${{ needs.build-bundle.outputs.artifact_name }}

--- a/.github/workflows/pr-linux.yml
+++ b/.github/workflows/pr-linux.yml
@@ -24,7 +24,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      core:     ${{ steps.filter.outputs.core }}
+      appimage: ${{ steps.filter.outputs.appimage }}
+      deb:      ${{ steps.filter.outputs.deb }}
+      rpm:      ${{ steps.filter.outputs.rpm }}
+      flatpak:  ${{ steps.filter.outputs.flatpak }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core:
+              - "lib/**"
+              - "linux/**"
+              - "external/**"
+              - "packages/bclibc_ffi/**"
+              - "pubspec.yaml"
+              - ".github/workflows/build.yml"
+              - ".github/workflows/build-portable.yml"
+              - ".github/workflows/pr-linux.yml"
+            appimage:
+              - ".github/workflows/build-appimage.yml"
+            deb:
+              - "deb/**"
+              - "flatpak/*.desktop"
+              - "flatpak/*.metainfo.xml"
+              - ".github/workflows/build-deb.yml"
+            rpm:
+              - "rpm/**"
+              - "flatpak/*.desktop"
+              - "flatpak/*.metainfo.xml"
+              - ".github/workflows/build-rpm.yml"
+            flatpak:
+              - "flatpak/**"
+              - ".github/workflows/build-flatpak.yml"
+
   build-bundle:
+    needs: changes
+    if: |
+      needs.changes.outputs.core     == 'true' ||
+      needs.changes.outputs.appimage == 'true' ||
+      needs.changes.outputs.deb      == 'true' ||
+      needs.changes.outputs.rpm      == 'true' ||
+      needs.changes.outputs.flatpak  == 'true'
     permissions:
       pull-requests: write
       issues: write
@@ -34,7 +79,11 @@ jobs:
       retention_days: 1
 
   build-appimage:
-    needs: build-bundle
+    needs: [changes, build-bundle]
+    if: |
+      always() &&
+      needs.build-bundle.result == 'success' &&
+      (needs.changes.outputs.core == 'true' || needs.changes.outputs.appimage == 'true')
     permissions:
       pull-requests: write
       issues: write
@@ -45,7 +94,11 @@ jobs:
       bundle_artifact_name: ${{ needs.build-bundle.outputs.artifact_name }}
 
   build-deb:
-    needs: build-bundle
+    needs: [changes, build-bundle]
+    if: |
+      always() &&
+      needs.build-bundle.result == 'success' &&
+      (needs.changes.outputs.core == 'true' || needs.changes.outputs.deb == 'true')
     permissions:
       pull-requests: write
       issues: write
@@ -56,7 +109,11 @@ jobs:
       bundle_artifact_name: ${{ needs.build-bundle.outputs.artifact_name }}
 
   build-rpm:
-    needs: build-bundle
+    needs: [changes, build-bundle]
+    if: |
+      always() &&
+      needs.build-bundle.result == 'success' &&
+      (needs.changes.outputs.core == 'true' || needs.changes.outputs.rpm == 'true')
     permissions:
       pull-requests: write
       issues: write
@@ -67,7 +124,11 @@ jobs:
       bundle_artifact_name: ${{ needs.build-bundle.outputs.artifact_name }}
 
   build-flatpak:
-    needs: build-bundle
+    needs: [changes, build-bundle]
+    if: |
+      always() &&
+      needs.build-bundle.result == 'success' &&
+      (needs.changes.outputs.core == 'true' || needs.changes.outputs.flatpak == 'true')
     permissions:
       pull-requests: write
       issues: write


### PR DESCRIPTION
## Summary
Consolidated Linux build workflow triggers into a single orchestrator workflow (`pr-linux.yml`) that calls reusable workflows, eliminating duplicate trigger configurations across multiple build files.

## Key Changes
- **New workflow**: Added `.github/workflows/pr-linux.yml` as the primary entry point for Linux PR builds
  - Triggers on changes to Linux-related paths and build workflow files
  - Orchestrates builds for portable, AppImage, deb, rpm, and Flatpak formats
  - Implements job dependencies to ensure portable bundle builds first
  - Sets 1-day artifact retention for PR builds
  
- **Refactored workflows**: Removed `pull_request` triggers from:
  - `build-portable.yml`
  - `build-appimage.yml`
  - `build-deb.yml`
  - `build-rpm.yml`
  - `build-flatpak.yml`
  
  These now only respond to `workflow_call` events, making them reusable components

## Implementation Details
- All reusable workflows maintain their input parameters for flexibility
- Job dependencies ensure the portable bundle is built before dependent formats (AppImage, deb, rpm, Flatpak)
- Centralized path filtering in `pr-linux.yml` reduces maintenance burden
- Permissions for PR interactions are set at the orchestrator level
- Short artifact retention (1 day) configured for PR builds to save storage

https://claude.ai/code/session_0121SRHWMa6q4BD8QFiNLbDP