### PR TITLE
Add WinGet package publishing workflow

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,0 +1,51 @@
+name: Publish to WinGet
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        description: "Release tag (e.g. v0.1.14)"
+        required: true
+        type: string
+      version:
+        description: "WinGet package version (e.g. 0.1.14.0)"
+        required: true
+        type: string
+    secrets:
+      WINGET_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag (e.g. v0.1.14)"
+        required: true
+        type: string
+      version:
+        description: "WinGet package version (e.g. 0.1.14.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  winget:
+    runs-on: windows-latest
+    steps:
+      - name: Download wingetcreate
+        run: |
+          Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+        shell: pwsh
+
+      - name: Submit to WinGet
+        run: |
+          $TAG     = "${{ inputs.tag_name }}"
+          $VERSION = "${{ inputs.version }}"
+          $URL     = "https://github.com/o-murphy/ebalistyka-app/releases/download/$TAG/ebalistyka_windows_x86_64.zip"
+
+          .\wingetcreate.exe update o-murphy.ebalistyka `
+            --version $VERSION `
+            --urls $URL `
+            --submit `
+            --token "${{ secrets.WINGET_TOKEN }}"
+        shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,3 +317,12 @@ jobs:
     with:
       tag_name: ${{ github.ref_name }}
     secrets: inherit
+
+  publish-winget:
+    if: github.ref_type == 'tag' && !contains(github.ref_name, '-')
+    needs: [prepare-version, release]
+    uses: ./.github/workflows/publish-winget.yml
+    with:
+      tag_name: ${{ github.ref_name }}
+      version: ${{ needs.prepare-version.outputs.version }}.0
+    secrets: inherit


### PR DESCRIPTION
## Summary
Adds automated publishing of releases to the Windows Package Manager (WinGet) repository.

## Changes
- **New workflow file** (`.github/workflows/publish-winget.yml`):
  - Reusable workflow that downloads `wingetcreate` tool
  - Submits package updates to WinGet using the official submission API
  - Accepts `tag_name` and `version` as inputs
  - Requires `WINGET_TOKEN` secret for authentication
  - Supports both `workflow_call` (from other workflows) and `workflow_dispatch` (manual trigger)

- **Updated release workflow** (`.github/workflows/release.yml`):
  - Added `publish-winget` job that triggers after successful release
  - Automatically publishes to WinGet for tagged releases (excluding pre-releases with `-` in tag name)
  - Passes release tag and computed version (with `.0` suffix for WinGet format) to the new workflow
  - Inherits secrets from parent workflow

## Implementation Details
- The WinGet submission targets the `o-murphy.ebalistyka` package
- Downloads the Windows x86_64 binary from the GitHub release
- Version format conversion: `v0.1.14` → `0.1.14.0` (WinGet requires 4-part version)
- Only publishes on stable releases (filters out pre-release tags containing `-`)

https://claude.ai/code/session_01MrYjWnHEPs2stHwSyKNMF8