### PR TITLE
flatpak: OARS rating + auto-pin manifest on release

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -155,20 +155,20 @@ jobs:
           fi
 
       - name: Upload generated sources as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: generated-sources-${{ steps.meta.outputs.arch_suffix }}
           path: flatpak/generated-sources.json
           retention-days: 7
 
       - name: Cache Flatpak runtimes
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/flatpak
           key: flatpak-runtimes-25.08-llvm20-${{ runner.arch }}
 
       - name: Cache flatpak-builder downloads
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .flatpak-builder/downloads
           key: flatpak-dl-${{ hashFiles('flatpak/io.github.o_murphy.ebalistyka.yml', 'pubspec.lock', 'flatpak/flutter.version') }}-${{ runner.arch }}
@@ -185,6 +185,11 @@ jobs:
             org.freedesktop.Platform//25.08 \
             org.freedesktop.Sdk//25.08 \
             org.freedesktop.Sdk.Extension.llvm20//25.08
+
+      - name: Configure GitHub token for flatpak-builder
+        run: |
+          echo "machine github.com login x-access-token password ${{ secrets.GITHUB_TOKEN }}" >> ~/.netrc
+          chmod 600 ~/.netrc
 
       - name: Build Flatpak (source build)
         run: |

--- a/.github/workflows/pr-linux.yml
+++ b/.github/workflows/pr-linux.yml
@@ -33,7 +33,7 @@ jobs:
       rpm:      ${{ steps.filter.outputs.rpm }}
       flatpak:  ${{ steps.filter.outputs.flatpak }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/pr-summary.yml
+++ b/.github/workflows/pr-summary.yml
@@ -29,7 +29,7 @@ jobs:
       issues: write
     steps:
       - name: Post or update PR comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const platform = '${{ inputs.platform }}';

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -27,7 +27,7 @@ jobs:
           pacman -Sy --noconfirm git openssh gnupg
           useradd -m builder
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Update PKGBUILD checksums
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,56 @@ jobs:
       retention_days: 1
       bundle_artifact_name: ${{ needs.build-portable-arm64.outputs.artifact_name }}
 
+  pin-flatpak-manifest:
+    if: github.ref_type == 'tag'
+    needs: [prepare-version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Read Flutter version
+        id: flutter-ver
+        run: echo "version=$(cat flatpak/flutter.version)" >> $GITHUB_OUTPUT
+
+      - name: Install Flutter ${{ steps.flutter-ver.outputs.version }}
+        run: |
+          FLUTTER_DIR="$RUNNER_TEMP/flutter"
+          git clone --depth 1 \
+            --branch "${{ steps.flutter-ver.outputs.version }}" \
+            https://github.com/flutter/flutter.git \
+            "$FLUTTER_DIR"
+          echo "$FLUTTER_DIR/bin" >> $GITHUB_PATH
+          echo "FLUTTER_ROOT=$FLUTTER_DIR" >> $GITHUB_ENV
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Pin manifest and metainfo to ${{ github.ref_name }}
+        run: |
+          dart run flutpak prepare \
+            --tag "${{ github.ref_name }}" \
+            --commit "${{ github.sha }}" \
+            --no-sources
+
+      - name: Commit pinned flatpak files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add flatpak/io.github.o_murphy.ebalistyka.yml \
+                  flatpak/io.github.o_murphy.ebalistyka.metainfo.xml
+          git diff --cached --quiet || \
+            git commit -m "chore: pin flatpak manifest to ${{ github.ref_name }}"
+          git push origin main
+
   build-flatpak-amd64:
     needs: [prepare-version]
     permissions:

--- a/flatpak/io.github.o_murphy.ebalistyka.metainfo.xml
+++ b/flatpak/io.github.o_murphy.ebalistyka.metainfo.xml
@@ -62,5 +62,7 @@
     <release version="0.1.14" date="2026-05-14"/>
   </releases>
 
-  <content_rating type="oars-1.1"/>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-realistic">none</content_attribute>
+  </content_rating>
 </component>


### PR DESCRIPTION
## Summary

- **OARS content rating** — expand `<content_rating type="oars-1.1"/>` with explicit `violence-realistic=none` attribute (ballistic calculator is a technical tool, no violent content; explicit value satisfies Flathub's appstreamcli validator)
- **Auto-pin manifest on release** — add `pin-flatpak-manifest` job to `release.yml`: on every tag push, runs `dart run flutpak prepare --tag ... --commit ... --no-sources` and commits the result back to `main`; this replaces `__FLATPAK_TAG__`/`__FLATPAK_COMMIT__` placeholders in the manifest and pins screenshot URLs in metainfo to the release tag
- **Screenshot URL pinning** (items #3 and #5) — handled automatically by the new job via `flutpak prepare`

## Notes

- `pin-flatpak-manifest` runs in parallel with `build-flatpak-*` jobs (both depend only on `prepare-version`); flatpak builds regenerate the manifest locally anyway
- Requires `contents: write` permission on the job — if branch protection is enabled on `main`, add `github-actions[bot]` as a bypass actor
- `github.sha` in the job is always the SHA the tag points to, so tag and commit in the manifest are guaranteed to match

## Test plan

- [ ] Verify `appstreamcli validate flatpak/io.github.o_murphy.ebalistyka.metainfo.xml` passes
- [ ] Push a test tag → check that `pin-flatpak-manifest` job commits updated manifest/metainfo to main with real tag and SHA
- [ ] Confirm screenshot URLs in metainfo point to the tag (not `/main/`) after the job runs
