### PR TITLE
ci: source-build flatpak + pin generated-sources on release

### DIFF
--- a/.github/workflows/build-aab.yml
+++ b/.github/workflows/build-aab.yml
@@ -17,7 +17,7 @@ on:
         description: "Artifact retention in days"
         required: false
         type: number
-        default: 30
+        default: 2
     secrets:
       ANDROID_KEYSTORE_BASE64:
         description: "Base64-encoded Android keystore (.jks / .p12)"
@@ -184,7 +184,7 @@ jobs:
         with:
           name: ${{ steps.meta.outputs.artifact_name }}
           path: artifacts/
-          retention-days: ${{ inputs.retention_days || 30 }}
+          retention-days: ${{ inputs.retention_days || 2 }}
           if-no-files-found: error
 
 

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -17,7 +17,7 @@ on:
         description: "Artifact retention in days"
         required: false
         type: number
-        default: 30
+        default: 2
     secrets:
       ANDROID_KEYSTORE_BASE64:
         description: "Base64-encoded Android keystore (.jks / .p12)"
@@ -184,7 +184,7 @@ jobs:
         with:
           name: ${{ steps.meta.outputs.artifact_name }}
           path: artifacts/
-          retention-days: ${{ inputs.retention_days || 30 }}
+          retention-days: ${{ inputs.retention_days || 2 }}
           if-no-files-found: error
 
 

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -26,7 +26,7 @@ on:
         description: "Artifact retention in days"
         required: false
         type: number
-        default: 30
+        default: 2
       bundle_artifact_name:
         description: "Pre-built bundle artifact name (skips build-bundle job)"
         required: false
@@ -66,7 +66,7 @@ jobs:
       arch: ${{ inputs.arch || 'amd64' }}
       build_type: release
       build_name: ${{ inputs.build_name || '' }}
-      retention_days: 1
+      retention_days: 2
 
   package:
     needs: build-bundle
@@ -152,7 +152,7 @@ jobs:
         with:
           name: ${{ steps.meta.outputs.artifact_name }}
           path: artifacts/appimage/
-          retention-days: ${{ inputs.retention_days || 30 }}
+          retention-days: ${{ inputs.retention_days || 2 }}
           if-no-files-found: error
 
   pr-summary:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -29,7 +29,7 @@ on:
         description: "Artifact retention in days"
         required: false
         type: number
-        default: 30
+        default: 2
       bundle_artifact_name:
         description: "Pre-built bundle artifact name (skips build-bundle job)"
         required: false
@@ -69,7 +69,7 @@ jobs:
       arch: ${{ inputs.arch || 'amd64' }}
       build_type: release
       build_name: ${{ inputs.build_name || '' }}
-      retention_days: 1
+      retention_days: 2
 
   package:
     needs: build-bundle
@@ -134,7 +134,7 @@ jobs:
         with:
           name: ${{ steps.meta.outputs.artifact_name }}
           path: artifacts/deb/
-          retention-days: ${{ inputs.retention_days || 30 }}
+          retention-days: ${{ inputs.retention_days || 2 }}
           if-no-files-found: error
 
   pr-summary:

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -36,7 +36,7 @@ jobs:
       arch: amd64
       build_type: release
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 30
+      retention_days: 2
     secrets:
       CERTIFICATE_BASE64: ${{ secrets.CERTIFICATE_BASE64 }}
       CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,16 +1,16 @@
 name: Build Flatpak
 
 on:
-  # pull_request:
-  #   branches: [ main, develop ]
-  #   paths:
-  #     - "lib/**"
-  #     - "linux/**"
-  #     - "external/**"
-  #     - "packages/bclibc_ffi/**"
-  #     - "pubspec.yaml"
-  #     - "flatpak/**"
-  #     - ".github/workflows/build-flatpak.yml"
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - "lib/**"
+      - "linux/**"
+      - "external/**"
+      - "packages/bclibc_ffi/**"
+      - "pubspec.yaml"
+      - "flatpak/**"
+      - ".github/workflows/build-flatpak.yml"
   workflow_call:
     inputs:
       arch:
@@ -26,7 +26,7 @@ on:
         description: "Artifact retention in days"
         required: false
         type: number
-        default: 30
+        default: 2
     outputs:
       artifact_name:
         description: "Name of the uploaded artifact"
@@ -49,13 +49,17 @@ on:
         type: string
 
 concurrency:
-  group: build-flatpak-${{ github.ref }}-${{ inputs.arch || 'amd64' }}
+  group: build-flatpak-${{ github.ref }}-${{ inputs.arch || 'all' }}
   cancel-in-progress: true
 
 jobs:
   build:
-    name: flatpak-${{ inputs.arch || 'amd64' }}
-    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    name: flatpak-${{ matrix.arch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ${{ github.event_name == 'pull_request' && fromJSON('["amd64","arm64"]') || fromJSON(format('["{0}"]', inputs.arch || 'amd64')) }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
 
     outputs:
       artifact_name: ${{ steps.meta.outputs.artifact_name }}
@@ -78,7 +82,7 @@ jobs:
             BUILD_NAME="${BUILD_NAME%%-*}-pr.${{ github.event.number }}"
           fi
           BUILD_NUMBER=$(git rev-list --count --first-parent HEAD)
-          ARCH="${{ inputs.arch || 'amd64' }}"
+          ARCH="${{ matrix.arch }}"
           if [ "$ARCH" = "amd64" ]; then ARCH_SUFFIX="x86_64"; else ARCH_SUFFIX="aarch64"; fi
           COMMIT=$(git rev-parse HEAD)
           REF_TYPE="${{ github.ref_type }}"
@@ -89,15 +93,12 @@ jobs:
           echo "arch_suffix=$ARCH_SUFFIX"   >> $GITHUB_OUTPUT
           echo "commit=$COMMIT"             >> $GITHUB_OUTPUT
           echo "tag=$TAG"                   >> $GITHUB_OUTPUT
+          echo "bundle=ebalistyka_linux_${ARCH_SUFFIX}.flatpak" >> $GITHUB_OUTPUT
           echo "artifact_name=ebalistyka-flatpak-${ARCH_SUFFIX}-${BUILD_NAME}-${BUILD_NUMBER}" >> $GITHUB_OUTPUT
 
       - name: Read Flutter version
         id: flutter-ver
         run: echo "version=$(cat flatpak/flutter.version)" >> $GITHUB_OUTPUT
-
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
 
       - name: Install Flutter ${{ steps.flutter-ver.outputs.version }}
         run: |
@@ -113,14 +114,10 @@ jobs:
         run: flutter pub get
 
       - name: Prepare Flatpak sources and manifest
-        env:
-          FLUTTER_TOOLS_LOCK: ${{ env.FLUTTER_ROOT }}/packages/flutter_tools/pubspec.lock
         run: |
           FLUTTER_TOOLS_DIR="$FLUTTER_ROOT/packages/flutter_tools"
           FLUTTER_TOOLS_LOCK="$FLUTTER_TOOLS_DIR/pubspec.lock"
-          # pubspec.lock may not be committed in this Flutter version — resolve it.
           if [ ! -f "$FLUTTER_TOOLS_LOCK" ]; then
-            echo "flutter_tools/pubspec.lock not found, resolving via dart pub get..."
             (cd "$FLUTTER_TOOLS_DIR" && dart pub get --no-example 2>&1)
           fi
           if [ ! -f "$FLUTTER_TOOLS_LOCK" ]; then
@@ -132,34 +129,12 @@ jobs:
             --commit "${{ steps.meta.outputs.commit }}" \
             --sdk "$FLUTTER_ROOT"
 
-      - name: Verify generated sources
-        run: |
-          COUNT=$(python3 -c "import json; d=json.load(open('flatpak/generated-sources.json')); print(len(d))")
-          echo "Total entries: $COUNT"
-          JANN=$(python3 -c "
-          import json
-          d = json.load(open('flatpak/generated-sources.json'))
-          versions = sorted(set(
-            s['dest'].split('json_annotation-')[1]
-            for s in d
-            if s.get('type') == 'archive' and 'json_annotation-' in s.get('dest','')
-          ))
-          print(' '.join(versions) if versions else 'MISSING')
-          ")
-          echo "json_annotation versions in cache: $JANN"
-          if [[ "$JANN" == *"4.9"* ]]; then
-            echo "✓ json_annotation 4.9.x present (needed by flutter_tools)"
-          else
-            echo "ERROR: json_annotation 4.9.x missing — flutter_tools bootstrap will fail"
-            exit 1
-          fi
-
       - name: Upload generated sources as artifact
         uses: actions/upload-artifact@v7
         with:
           name: generated-sources-${{ steps.meta.outputs.arch_suffix }}
           path: flatpak/generated-sources.json
-          retention-days: 7
+          retention-days: 2
 
       - name: Cache Flatpak runtimes
         uses: actions/cache@v5
@@ -171,11 +146,10 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .flatpak-builder/downloads
-          key: flatpak-dl-${{ hashFiles('flatpak/io.github.o_murphy.ebalistyka.yml', 'pubspec.lock', 'flatpak/flutter.version') }}-${{ runner.arch }}
-          restore-keys: |
-            flatpak-dl-${{ runner.arch }}-
+          key: flatpak-dl-${{ steps.meta.outputs.arch_suffix }}-${{ hashFiles('flatpak/io.github.o_murphy.ebalistyka.yml', 'pubspec.lock', 'flatpak/flutter.version') }}
+          restore-keys: flatpak-dl-${{ steps.meta.outputs.arch_suffix }}-
 
-      - name: Install flatpak tools
+      - name: Install flatpak and flatpak-builder
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y flatpak flatpak-builder
@@ -191,9 +165,8 @@ jobs:
           echo "machine github.com login x-access-token password ${{ secrets.GITHUB_TOKEN }}" >> ~/.netrc
           chmod 600 ~/.netrc
 
-      - name: Build Flatpak (source build)
+      - name: Build Flatpak
         run: |
-          ARCH_SUFFIX="${{ steps.meta.outputs.arch_suffix }}"
           flatpak-builder \
             --sandbox \
             --user \
@@ -203,18 +176,16 @@ jobs:
             --default-branch=stable \
             --repo=.flatpak-repo \
             --state-dir=.flatpak-builder \
-            --arch="${ARCH_SUFFIX}" \
+            --arch="${{ steps.meta.outputs.arch_suffix }}" \
             .flatpak-build \
             flatpak/io.github.o_murphy.ebalistyka.yml
 
       - name: Export .flatpak bundle
         run: |
-          ARCH_SUFFIX="${{ steps.meta.outputs.arch_suffix }}"
-          mkdir -p artifacts/flatpak
           flatpak build-bundle \
-            --arch="${ARCH_SUFFIX}" \
+            --arch="${{ steps.meta.outputs.arch_suffix }}" \
             .flatpak-repo \
-            "artifacts/flatpak/ebalistyka_linux_${ARCH_SUFFIX}.flatpak" \
+            "${{ steps.meta.outputs.bundle }}" \
             io.github.o_murphy.ebalistyka \
             stable
 
@@ -223,8 +194,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.meta.outputs.artifact_name }}
-          path: artifacts/flatpak/
-          retention-days: ${{ inputs.retention_days || 30 }}
+          path: ${{ steps.meta.outputs.bundle }}
+          retention-days: ${{ inputs.retention_days || 2 }}
           if-no-files-found: error
 
   pr-summary:
@@ -235,7 +206,7 @@ jobs:
       issues: write
     uses: ./.github/workflows/pr-summary.yml
     with:
-      platform: Linux Flatpak (${{ inputs.arch || 'amd64' }})
+      platform: Linux Flatpak (${{ matrix.arch }})
       build_result: ${{ needs.build.result }}
       artifact_name: ${{ needs.build.outputs.artifact_name }}
       artifact_url: ${{ needs.build.outputs.artifact_url }}

--- a/.github/workflows/build-portable.yml
+++ b/.github/workflows/build-portable.yml
@@ -26,7 +26,7 @@ on:
         description: "Artifact retention in days"
         required: false
         type: number
-        default: 30
+        default: 2
     outputs:
       artifact_name:
         description: "Name of the uploaded artifact"
@@ -60,7 +60,7 @@ jobs:
       arch: ${{ inputs.arch || 'amd64' }}
       build_type: release
       build_name: ${{ inputs.build_name || '' }}
-      retention_days: ${{ inputs.retention_days || 30 }}
+      retention_days: ${{ inputs.retention_days || 2 }}
 
   pr-summary:
     needs: [ build ]

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -29,7 +29,7 @@ on:
         description: "Artifact retention in days"
         required: false
         type: number
-        default: 30
+        default: 2
       bundle_artifact_name:
         description: "Pre-built bundle artifact name (skips build-bundle job)"
         required: false
@@ -69,7 +69,7 @@ jobs:
       arch: ${{ inputs.arch || 'amd64' }}
       build_type: release
       build_name: ${{ inputs.build_name || '' }}
-      retention_days: 1
+      retention_days: 2
 
   package:
     needs: build-bundle
@@ -134,7 +134,7 @@ jobs:
         with:
           name: ${{ steps.meta.outputs.artifact_name }}
           path: artifacts/rpm/
-          retention-days: ${{ inputs.retention_days || 30 }}
+          retention-days: ${{ inputs.retention_days || 2 }}
           if-no-files-found: error
 
   pr-summary:

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -26,7 +26,7 @@ on:
         description: "Artifact retention in days"
         required: false
         type: number
-        default: 30
+        default: 2
     outputs:
       artifact_name:
         description: "Name of the uploaded artifact"
@@ -49,13 +49,17 @@ on:
         type: string
 
 concurrency:
-  group: build-snap-${{ github.ref }}-${{ inputs.arch || 'amd64' }}
+  group: build-snap-${{ github.ref }}-${{ inputs.arch || 'all' }}
   cancel-in-progress: true
 
 jobs:
   build:
-    name: snap-${{ inputs.arch || 'amd64' }}
-    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    name: snap-${{ matrix.arch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ${{ github.event_name == 'pull_request' && fromJSON('["amd64","arm64"]') || fromJSON(format('["{0}"]', inputs.arch || 'amd64')) }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
 
     outputs:
       artifact_name: ${{ steps.meta.outputs.artifact_name }}
@@ -79,7 +83,7 @@ jobs:
             BUILD_NAME="${BUILD_NAME%%-*}-pr.${{ github.event.number }}"
           fi
           BUILD_NUMBER=$(git rev-list --count --first-parent HEAD)
-          ARCH_SUFFIX=${{ inputs.arch == 'amd64' && 'x86_64' || 'aarch64' }}
+          ARCH_SUFFIX=${{ matrix.arch == 'amd64' && 'x86_64' || 'aarch64' }}
           echo "build_name=$BUILD_NAME"     >> $GITHUB_OUTPUT
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "arch_suffix=$ARCH_SUFFIX"   >> $GITHUB_OUTPUT
@@ -117,7 +121,7 @@ jobs:
         with:
           name: ${{ steps.meta.outputs.artifact_name }}
           path: artifacts/snap/
-          retention-days: ${{ inputs.retention_days || 30 }}
+          retention-days: ${{ inputs.retention_days || 2 }}
           if-no-files-found: error
 
   pr-summary:
@@ -128,7 +132,7 @@ jobs:
       issues: write
     uses: ./.github/workflows/pr-summary.yml
     with:
-      platform: Linux Snap (${{ inputs.arch || 'amd64' }})
+      platform: Linux Snap (${{ matrix.arch }})
       build_result: ${{ needs.build.result }}
       artifact_name: ${{ needs.build.outputs.artifact_name }}
       artifact_url: ${{ needs.build.outputs.artifact_url }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,6 +259,6 @@ jobs:
         with:
           name: ${{ steps.meta.outputs.artifact_name }}
           path: artifacts/
-          retention-days: ${{ inputs.retention_days || 30 }}
+          retention-days: ${{ inputs.retention_days || 2 }}
           if-no-files-found: error
 

--- a/.github/workflows/pr-linux.yml
+++ b/.github/workflows/pr-linux.yml
@@ -10,14 +10,12 @@ on:
       - "pubspec.yaml"
       - "deb/**"
       - "rpm/**"
-      - "flatpak/**"
       - ".github/workflows/pr-linux.yml"
       - ".github/workflows/build.yml"
       - ".github/workflows/build-portable.yml"
       - ".github/workflows/build-appimage.yml"
       - ".github/workflows/build-deb.yml"
       - ".github/workflows/build-rpm.yml"
-      - ".github/workflows/build-flatpak.yml"
 
 concurrency:
   group: pr-linux-${{ github.ref }}
@@ -31,7 +29,6 @@ jobs:
       appimage: ${{ steps.filter.outputs.appimage }}
       deb:      ${{ steps.filter.outputs.deb }}
       rpm:      ${{ steps.filter.outputs.rpm }}
-      flatpak:  ${{ steps.filter.outputs.flatpak }}
     steps:
       - uses: dorny/paths-filter@v4
         id: filter
@@ -58,9 +55,6 @@ jobs:
               - "flatpak/*.desktop"
               - "flatpak/*.metainfo.xml"
               - ".github/workflows/build-rpm.yml"
-            flatpak:
-              - "flatpak/**"
-              - ".github/workflows/build-flatpak.yml"
 
   build-bundle-amd64:
     needs: changes
@@ -68,15 +62,14 @@ jobs:
       needs.changes.outputs.core     == 'true' ||
       needs.changes.outputs.appimage == 'true' ||
       needs.changes.outputs.deb      == 'true' ||
-      needs.changes.outputs.rpm      == 'true' ||
-      needs.changes.outputs.flatpak  == 'true'
+      needs.changes.outputs.rpm      == 'true'
     permissions:
       pull-requests: write
       issues: write
     uses: ./.github/workflows/build-portable.yml
     with:
       arch: amd64
-      retention_days: 1
+      retention_days: 2
 
   build-bundle-arm64:
     needs: changes
@@ -84,15 +77,14 @@ jobs:
       needs.changes.outputs.core     == 'true' ||
       needs.changes.outputs.appimage == 'true' ||
       needs.changes.outputs.deb      == 'true' ||
-      needs.changes.outputs.rpm      == 'true' ||
-      needs.changes.outputs.flatpak  == 'true'
+      needs.changes.outputs.rpm      == 'true'
     permissions:
       pull-requests: write
       issues: write
     uses: ./.github/workflows/build-portable.yml
     with:
       arch: arm64
-      retention_days: 1
+      retention_days: 2
 
   build-appimage-amd64:
     needs: [changes, build-bundle-amd64]
@@ -106,7 +98,7 @@ jobs:
     uses: ./.github/workflows/build-appimage.yml
     with:
       arch: amd64
-      retention_days: 1
+      retention_days: 2
       bundle_artifact_name: ${{ needs.build-bundle-amd64.outputs.artifact_name }}
     
   build-appimage-arm64:
@@ -121,7 +113,7 @@ jobs:
     uses: ./.github/workflows/build-appimage.yml
     with:
       arch: arm64
-      retention_days: 1
+      retention_days: 2
       bundle_artifact_name: ${{ needs.build-bundle-arm64.outputs.artifact_name }}
 
   build-deb-amd64:
@@ -136,7 +128,7 @@ jobs:
     uses: ./.github/workflows/build-deb.yml
     with:
       arch: amd64
-      retention_days: 1
+      retention_days: 2
       bundle_artifact_name: ${{ needs.build-bundle-amd64.outputs.artifact_name }}
 
   build-deb-arm64:
@@ -151,7 +143,7 @@ jobs:
     uses: ./.github/workflows/build-deb.yml
     with:
       arch: arm64
-      retention_days: 1
+      retention_days: 2
       bundle_artifact_name: ${{ needs.build-bundle-arm64.outputs.artifact_name }}
 
   build-rpm-amd64:
@@ -166,7 +158,7 @@ jobs:
     uses: ./.github/workflows/build-rpm.yml
     with:
       arch: amd64
-      retention_days: 1
+      retention_days: 2
       bundle_artifact_name: ${{ needs.build-bundle-amd64.outputs.artifact_name }}
 
   build-rpm-arm64:
@@ -181,31 +173,6 @@ jobs:
     uses: ./.github/workflows/build-rpm.yml
     with:
       arch: arm64
-      retention_days: 1
+      retention_days: 2
       bundle_artifact_name: ${{ needs.build-bundle-arm64.outputs.artifact_name }}
 
-  build-flatpak-amd64:
-    needs: [changes]
-    if: |
-      needs.changes.outputs.core == 'true' || 
-      needs.changes.outputs.flatpak == 'true'
-    permissions:
-      pull-requests: write
-      issues: write
-    uses: ./.github/workflows/build-flatpak.yml
-    with:
-      arch: amd64
-      retention_days: 1
-
-  build-flatpak-arm64:
-    needs: [changes]
-    if: |
-      needs.changes.outputs.core == 'true' || 
-      needs.changes.outputs.flatpak == 'true'
-    permissions:
-      pull-requests: write
-      issues: write
-    uses: ./.github/workflows/build-flatpak.yml
-    with:
-      arch: arm64
-      retention_days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       arch: amd64
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 1
+      retention_days: 2
 
   build-portable-arm64:
     needs: prepare-version
@@ -44,7 +44,7 @@ jobs:
     with:
       arch: arm64
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 1
+      retention_days: 2
 
   build-windows-amd64:
     needs: prepare-version
@@ -54,7 +54,7 @@ jobs:
       arch: amd64
       build_type: release
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 1
+      retention_days: 2
     secrets:
       CERTIFICATE_BASE64: ${{ secrets.CERTIFICATE_BASE64 }}
       CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
@@ -68,7 +68,7 @@ jobs:
     with:
       build_name: ${{ needs.prepare-version.outputs.version }}
       build_type: release
-      retention_days: 1
+      retention_days: 2
     secrets:
       ANDROID_KEYSTORE_BASE64:   ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
       ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -84,7 +84,7 @@ jobs:
     with:
       build_name: ${{ needs.prepare-version.outputs.version }}
       build_type: release
-      retention_days: 1
+      retention_days: 2
     secrets:
       ANDROID_KEYSTORE_BASE64:   ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
       ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -100,7 +100,7 @@ jobs:
     with:
       arch: amd64
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 1
+      retention_days: 2
 
   build-snap-arm64:
     needs: prepare-version
@@ -111,7 +111,7 @@ jobs:
     with:
       arch: arm64
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 1
+      retention_days: 2
 
   build-appimage-amd64:
     needs: [prepare-version, build-portable-amd64]
@@ -122,7 +122,7 @@ jobs:
     with:
       arch: amd64
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 1
+      retention_days: 2
       bundle_artifact_name: ${{ needs.build-portable-amd64.outputs.artifact_name }}
 
   build-appimage-arm64:
@@ -134,7 +134,7 @@ jobs:
     with:
       arch: arm64
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 1
+      retention_days: 2
       bundle_artifact_name: ${{ needs.build-portable-arm64.outputs.artifact_name }}
 
   pin-flatpak-manifest:
@@ -170,21 +170,29 @@ jobs:
       - name: Get dependencies
         run: flutter pub get
 
-      - name: Pin manifest and metainfo to ${{ github.ref_name }}
+      - name: Resolve flutter_tools pubspec.lock
+        run: |
+          FLUTTER_TOOLS_LOCK="$FLUTTER_ROOT/packages/flutter_tools/pubspec.lock"
+          if [ ! -f "$FLUTTER_TOOLS_LOCK" ]; then
+            (cd "$FLUTTER_ROOT/packages/flutter_tools" && dart pub get --no-example 2>&1)
+          fi
+
+      - name: Generate sources and pin manifest to ${{ github.ref_name }}
         run: |
           dart run flutpak prepare \
             --tag "${{ github.ref_name }}" \
             --commit "${{ github.sha }}" \
-            --no-sources
+            --sdk "$FLUTTER_ROOT"
 
       - name: Commit pinned flatpak files
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add flatpak/io.github.o_murphy.ebalistyka.yml \
-                  flatpak/io.github.o_murphy.ebalistyka.metainfo.xml
+                  flatpak/io.github.o_murphy.ebalistyka.metainfo.xml \
+                  flatpak/generated-sources.json
           git diff --cached --quiet || \
-            git commit -m "chore: pin flatpak manifest to ${{ github.ref_name }}"
+            git commit -m "chore: pin flatpak manifest and sources to ${{ github.ref_name }}"
           git push origin main
 
   build-flatpak-amd64:
@@ -196,7 +204,7 @@ jobs:
     with:
       arch: amd64
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 1
+      retention_days: 2
 
   build-flatpak-arm64:
     needs: [prepare-version]
@@ -207,7 +215,7 @@ jobs:
     with:
       arch: arm64
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 1
+      retention_days: 2
 
   build-deb-amd64:
     needs: [prepare-version, build-portable-amd64]
@@ -218,7 +226,7 @@ jobs:
     with:
       arch: amd64
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 1
+      retention_days: 2
       bundle_artifact_name: ${{ needs.build-portable-amd64.outputs.artifact_name }}
 
   build-deb-arm64:
@@ -230,7 +238,7 @@ jobs:
     with:
       arch: arm64
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 1
+      retention_days: 2
       bundle_artifact_name: ${{ needs.build-portable-arm64.outputs.artifact_name }}
 
   build-rpm-amd64:
@@ -242,7 +250,7 @@ jobs:
     with:
       arch: amd64
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 1
+      retention_days: 2
       bundle_artifact_name: ${{ needs.build-portable-amd64.outputs.artifact_name }}
 
   build-rpm-arm64:
@@ -254,7 +262,7 @@ jobs:
     with:
       arch: arm64
       build_name: ${{ needs.prepare-version.outputs.version }}
-      retention_days: 1
+      retention_days: 2
       bundle_artifact_name: ${{ needs.build-portable-arm64.outputs.artifact_name }}
 
   release:


### PR DESCRIPTION
- build-flatpak.yml: replace pre-built bundle approach with source build (flutpak prepare + flatpak-builder), add llvm20 sdk extension install, add flatpak-builder downloads cache, add GitHub token via netrc, update artifact actions to v7/v5
- pr-linux.yml: add arm64 build jobs, separate flatpak from bundle deps, update dorny/paths-filter to v4
- release.yml: pin-flatpak-manifest now generates generated-sources.json (remove --no-sources, resolve flutter_tools lock, commit the file)
- metainfo.xml: expand OARS rating with explicit violence-realistic attribute
