### PR TITLE
feat(bclibc_ffi): migrate to BCShot — physics conversion centralized in C++

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install Flutter ${{ steps.flutter-ver.outputs.version }}
         id: flutter
-        uses: o-murphy/flutpak/.github/actions/flutter@v0.4.0-beta.4
+        uses: o-murphy/flutpak/.github/actions/flutter@v0.4.0-rc.2
         with:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           cache: true
@@ -92,7 +92,7 @@ jobs:
         run: flutter pub get
 
       - name: Generate manifest and validate
-        uses: o-murphy/flutpak/.github/actions/generate@v0.4.0-beta.4
+        uses: o-murphy/flutpak/.github/actions/generate@v0.4.0-rc.2
         with:
           tag: ${{ inputs.tag }}
           commit: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -156,7 +156,7 @@ jobs:
 
       - name: Build Flatpak
         id: build-flatpak
-        uses: o-murphy/flutpak/.github/actions/build-flatpak@v0.4.0-beta.4
+        uses: o-murphy/flutpak/.github/actions/build-flatpak@v0.4.0-rc.2
         with:
           manifest: flatpak/generated/io.github.o_murphy.ebalistyka.yml
           app-id: io.github.o_murphy.ebalistyka

--- a/.github/workflows/publish-flathub.yml
+++ b/.github/workflows/publish-flathub.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install Flutter ${{ steps.flutter-ver.outputs.version }}
         id: flutter
-        uses: o-murphy/flutpak/.github/actions/flutter@v0.4.0-beta.4
+        uses: o-murphy/flutpak/.github/actions/flutter@v0.4.0-rc.2
         with:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           cache: true
@@ -40,7 +40,7 @@ jobs:
         run: flutter pub get
 
       - name: Install flutpak
-        uses: o-murphy/flutpak/.github/actions/setup-flutpak@v0.4.0-beta.4
+        uses: o-murphy/flutpak/.github/actions/setup-flutpak@v0.4.0-rc.2
 
       - name: Generate Flathub manifest
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: Tests
+
+on:
+  pull_request:
+    paths:
+      - "lib/**"
+      - "test/**"
+      - "packages/**"
+      - "external/**"
+      - "pubspec.yaml"
+      - "pubspec.lock"
+      - "Makefile"
+      - ".github/workflows/test.yml"
+      - ".github/actions/flutter/**"
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FLUTTER_VERSION: "3.44.0"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Flutter
+        uses: ./.github/actions/flutter
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Download ObjectBox native library
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/objectbox/objectbox-dart/main/install.sh)
+          sudo cp lib/libobjectbox.so /usr/local/lib/
+          sudo ldconfig
+
+      - run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ aur/*.tar.gz
 
 # pre-compiled flutpak util
 flutpak
+
+# objectbox downloads
+download/objectbox*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## Unreleased
 [![GitHub release][GitHubCompareBadge]][Unreleased]
 
+### Changed
+- `packages/bclibc_ffi` (`calculator.dart`): `Calculator._toBcShotProps()` replaced with thin field mapper `_toBcShot()` — Coriolis trig (`_toCoriolis`: sin/cos lat/az, range/cross offsets) and atmosphere density (`_toAtmo`) removed from Dart; all physics conversion delegated to `BCLIBC_Shot::to_shot_props()` in C++ (Step 3a of bclibc-wrapper-consolidation)
+- `packages/bclibc_ffi` (`bclibc_ffi.dart`): added `BcShot` Dart value class, `_FillNativeShot` extension, and `BcLibC.*Shot()` API methods (`findApexShot`, `findMaxRangeShot`, `findZeroAngleShot`, `integrateShot`, `integrateAtShot`)
+- `packages/bclibc_ffi` (`bclibc_bindings.g.dart`): added `BCShot` native struct and `BCLIBCFFI_*_shot` lookup bindings (manually updated; regenerate with `dart run ffigen --config ffigen.yaml` after building bclibc)
+- `external/bclibc` submodule bumped to `caf42e0` — adds `BCShot` C struct and `BCLIBCFFI_*_shot()` entry points to `bclibc_ffi.h`; `BcShotProps` / `BCLIBCFFI_*` retained for backwards compatibility; `Vacuum` handled correctly (`pressure_hpa == 0` → zero density, no drag)
+
 
 ## v0.1.16 (2026-05-26)
 
 ### Changed
 - **App repo name** — slug changed from `o-murphy/ebalistyka-app` to `o-murphy/ebalistyka` to unify the app ID across all packaging formats; updated `repoSlug` constant in `lib/shared/constants/app_info.dart` and all workflow / CHANGELOG links
 - **Flutter** — default version bumped to 3.44.0 across all workflows
-- **flutpak** — bumped to `v0.4.0-beta.4`; generates Flathub-compatible manifest and `generated-sources.json`; icon config in `pubspec.yaml` updated to reference `app/share/icons/` at all sizes (16 → 1024 px)
+- **flutpak** — bumped to `v0.4.0-rc.2`; generates Flathub-compatible manifest and `generated-sources.json`; icon config in `pubspec.yaml` updated to reference `app/share/icons/` at all sizes (16 → 1024 px)
 - **App icons** — regenerated; icon and shared assets (`metainfo`, `desktop`, icons) moved to `app/share/` and reused across all packaging tools (AUR, deb, RPM, AppImage, Flatpak, Snap); Android launcher icons, Android/iOS/macOS/web splash images all regenerated from the new source
 - **objectbox** — `objectbox_flutter_libs` bumped to 5.3.2; Flatpak manifest, patch, and flutpak config updated accordingly; CRLF line endings in the 5.3.2 pub.dev archive handled via `strip_trailing_cr: true` (injects a `sed -i 's/\r//'` step before patching)
 

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,11 @@ else
   endif
 endif
 
-# Build the native shared library via CMake (still builds from external/bclibc)
+# Build the native shared library via CMake directly (used by generate/ffigen).
+# For running tests use `make test` which goes through `flutter build linux`.
+BCLIBC_BUILD_TYPE ?= Debug
 build-bclibc:
-	cmake -S external/bclibc -B build/bclibc -DCMAKE_BUILD_TYPE=Release
+	cmake -S external/bclibc -B build/bclibc -DCMAKE_BUILD_TYPE=$(BCLIBC_BUILD_TYPE)
 	cmake --build build/bclibc --parallel $(NPROC)
 
 # Re-generate Dart FFI bindings from the C header (now in the package)
@@ -107,7 +109,9 @@ generate: build-bclibc ffigen \
 	generate-reticles generate-icons \
 	generate-collection
 
-# Run all tests (native must be built first)
+# Run all tests (native must be built first via cmake).
+# Use `flutter build linux --debug` manually beforehand if you want
+# tests to run against the Flutter-bundled library instead.
 test: build-bclibc
 	flutter analyze && flutter test 2>&1
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -39,3 +39,4 @@ analyzer:
     - "lib/**/*.g.dart"
     - "lib/**/*.freezed.dart"
     - "lib/l10n/app_localizations.dart"
+    - "packages/reticle_gen/**"

--- a/flatpak/io.github.o_murphy.ebalistyka.yml
+++ b/flatpak/io.github.o_murphy.ebalistyka.yml
@@ -4,8 +4,7 @@
 # Run "flutpak generate" on every build to produce the final output in generated/.
 #
 # SAFE TO EDIT   finish-args, build-commands, build-options, sdk-extensions, modules
-# DO NOT REMOVE  __FLATPAK_TAG__ and __FLATPAK_COMMIT__ placeholders — required by generate
-# AUTO-INJECTED  patch sources are appended after generated-sources.json by generate
+# AUTO-INJECTED  tag, commit, modules, manifest.sources, generated-sources.json, and patches are set/appended by generate
 app-id: io.github.o_murphy.ebalistyka
 runtime: org.freedesktop.Platform
 runtime-version: '25.08'
@@ -13,23 +12,14 @@ sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.llvm20
 command: ebalistyka
-# Sandbox permissions — add or remove as your app requires.
+# Sandbox permissions — review and adjust for your app.
 finish-args:
   - --share=ipc
   - --socket=fallback-x11
   - --socket=wayland
   - --device=dri
+  - --share=network
 modules:
-  - name: bclibc
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DBCLIBC_BUILD_TESTS=OFF
-    sources:
-      - type: git
-        url: https://github.com/ballistics-lab/bclibc.git
-        tag: v1.0.6
-        commit: 26cb17bca86a52d58a05dff07ddfb62ce98445e2
   - name: ebalistyka
     buildsystem: simple
     build-options:
@@ -44,7 +34,7 @@ modules:
       prepend-ld-library-path: /usr/lib/sdk/llvm20/lib
       env:
         PUB_CACHE: /run/build/ebalistyka/.pub-cache
-        OBJECTBOX_PREBUILT_DIR: /run/build/ebalistyka/objectbox-c
+        OBJECTBOX_PREBUILT_DIR: /app
     # Build steps — review and customise for your project.
     build-commands:
       - cp flutter/bin/internal/engine.version flutter/bin/cache/engine-dart-sdk.stamp
@@ -67,26 +57,7 @@ modules:
       - install -Dm644 app/share/icons/hicolor/128x128/apps/io.github.o_murphy.ebalistyka.png /app/share/icons/hicolor/128x128/apps/io.github.o_murphy.ebalistyka.png
       - install -Dm644 app/share/icons/hicolor/256x256/apps/io.github.o_murphy.ebalistyka.png /app/share/icons/hicolor/256x256/apps/io.github.o_murphy.ebalistyka.png
       - install -Dm644 app/share/icons/hicolor/512x512/apps/io.github.o_murphy.ebalistyka.png /app/share/icons/hicolor/512x512/apps/io.github.o_murphy.ebalistyka.png
-    # Sources — do not remove __FLATPAK_TAG__ / __FLATPAK_COMMIT__.
     sources:
       - type: git
-        url: https://github.com/o-murphy/ebalistyka
-        tag: __FLATPAK_TAG__
-        commit: __FLATPAK_COMMIT__
+        url: https://github.com/o-murphy/ebalistyka-app
         disable-submodules: true
-      - type: archive
-        only-arches:
-          - x86_64
-        url: https://github.com/objectbox/objectbox-c/releases/download/v5.3.2/objectbox-linux-x64.tar.gz
-        sha256: 6dbb5450c36dd11ee9074f16ecc61e79b45ff43c2082934601f3166b39c8a613
-        dest: objectbox-c
-        strip-components: 0
-      - type: archive
-        only-arches:
-          - aarch64
-        url: https://github.com/objectbox/objectbox-c/releases/download/v5.3.2/objectbox-linux-aarch64.tar.gz
-        sha256: bdfbfbf4971057e11018ca6645697d8a40ebc7df56ccde63397cbb0e0609c0e8
-        dest: objectbox-c
-        strip-components: 0
-      # "flutpak generate" injects patch sources after this line.
-      - generated-sources.json

--- a/flatpak/modules/bclibc.yml
+++ b/flatpak/modules/bclibc.yml
@@ -6,5 +6,5 @@
   sources:
     - type: git
       url: https://github.com/ballistics-lab/bclibc.git
-      tag: v1.0.6
-      commit: 26cb17bca86a52d58a05dff07ddfb62ce98445e2
+      tag: v1.1.2
+      commit: 366d300403019058e1c0fb7a8b2451fcfe8071d3

--- a/flatpak/modules/objectbox-c.yml
+++ b/flatpak/modules/objectbox-c.yml
@@ -1,0 +1,17 @@
+- name: objectbox-c
+  buildsystem: simple
+  build-commands:
+    - install -Dm755 lib/libobjectbox.so /app/lib/libobjectbox.so
+  sources:
+    - type: archive
+      only-arches:
+        - x86_64
+      url: https://github.com/objectbox/objectbox-c/releases/download/v5.3.2/objectbox-linux-x64.tar.gz
+      sha256: 6dbb5450c36dd11ee9074f16ecc61e79b45ff43c2082934601f3166b39c8a613
+      strip-components: 0
+    - type: archive
+      only-arches:
+        - aarch64
+      url: https://github.com/objectbox/objectbox-c/releases/download/v5.3.2/objectbox-linux-aarch64.tar.gz
+      sha256: bdfbfbf4971057e11018ca6645697d8a40ebc7df56ccde63397cbb0e0609c0e8
+      strip-components: 0

--- a/lib/core/services/a7p_service.dart
+++ b/lib/core/services/a7p_service.dart
@@ -65,9 +65,13 @@ abstract final class A7pService {
       final tmp = await getTemporaryDirectory();
       final path = '${tmp.path}/$name';
       await File(path).writeAsBytes(bytes);
-      await Share.shareXFiles([
-        XFile(path, mimeType: 'application/octet-stream', name: name),
-      ]);
+      await SharePlus.instance.share(
+        ShareParams(
+          files: [
+            XFile(path, mimeType: 'application/octet-stream', name: name),
+          ],
+        ),
+      );
     } else {
       final savePath = await FilePicker.saveFile(
         fileName: name,

--- a/lib/core/services/ballistics_service_impl.dart
+++ b/lib/core/services/ballistics_service_impl.dart
@@ -50,8 +50,8 @@ _TableCalcResult _runTableCalculation(_TableCalcArgs args) {
       trajectoryRange: Distance(FC.targetDistance.maxRaw, Unit.meter),
       trajectoryStep: Distance.meter(stepM),
       filterFlags:
-          bclibc.BCTrajFlag.BC_TRAJ_FLAG_RANGE.value |
-          bclibc.BCTrajFlag.BC_TRAJ_FLAG_ZERO.value,
+          bclibc.BCLIBCFFI_TrajFlag.BCLIBCFFI_TRAJ_FLAG_RANGE.value |
+          bclibc.BCLIBCFFI_TrajFlag.BCLIBCFFI_TRAJ_FLAG_ZERO.value,
     );
     return (result, freshZeroElevRad);
   } catch (e, st) {
@@ -140,8 +140,8 @@ _HomeCalcResult _runHomeCalculation(_HomeCalcArgs args) {
       trajectoryRange: Distance.meter(trajectoryEndM),
       trajectoryStep: Distance.meter(internalStepM),
       filterFlags:
-          bclibc.BCTrajFlag.BC_TRAJ_FLAG_RANGE.value |
-          bclibc.BCTrajFlag.BC_TRAJ_FLAG_ZERO.value,
+          bclibc.BCLIBCFFI_TrajFlag.BCLIBCFFI_TRAJ_FLAG_RANGE.value |
+          bclibc.BCLIBCFFI_TrajFlag.BCLIBCFFI_TRAJ_FLAG_ZERO.value,
     );
     return (result, freshZeroElevRad, holdRad, tableHolds);
   } catch (e, st) {

--- a/lib/core/services/ebcp_service.dart
+++ b/lib/core/services/ebcp_service.dart
@@ -22,9 +22,13 @@ abstract final class EbcpService {
       final tmp = await getTemporaryDirectory();
       final path = '${tmp.path}/$name';
       await File(path).writeAsBytes(bytes);
-      await Share.shareXFiles([
-        XFile(path, mimeType: 'application/octet-stream', name: name),
-      ]);
+      await SharePlus.instance.share(
+        ShareParams(
+          files: [
+            XFile(path, mimeType: 'application/octet-stream', name: name),
+          ],
+        ),
+      );
     } else {
       final savePath = await FilePicker.saveFile(
         fileName: name,

--- a/lib/features/tables/table_html_exporter.dart
+++ b/lib/features/tables/table_html_exporter.dart
@@ -32,17 +32,19 @@ class TableHtmlExporter {
     await file.writeAsString(html, flush: true);
 
     if (Platform.isAndroid || Platform.isIOS) {
-      await Share.shareXFiles(
-        [
-          XFile(
-            file.path,
-            mimeType: 'text/html',
-            name: 'trajectory_table.html',
-          ),
-        ],
-        subject: details != null
-            ? '${details.weaponName} — ${l10n.tabTrajectory}'
-            : l10n.tabTrajectory,
+      await SharePlus.instance.share(
+        ShareParams(
+          files: [
+            XFile(
+              file.path,
+              mimeType: 'text/html',
+              name: 'trajectory_table.html',
+            ),
+          ],
+          subject: details != null
+              ? '${details.weaponName} — ${l10n.tabTrajectory}'
+              : l10n.tabTrajectory,
+        ),
       );
     } else {
       // Desktop: open HTML in the default browser

--- a/packages/bclibc_ffi/CHANGELOG.md
+++ b/packages/bclibc_ffi/CHANGELOG.md
@@ -1,3 +1,26 @@
+# Changelog
+
+## Unreleased
+
+## 0.1.0
+
+### Added
+- `BcShot` Dart value class — user-facing shot descriptor in natural units; all physics conversion (atmosphere density, Coriolis trig, PCHIP drag curve, cant sin/cos) is performed inside C++ by `BCLIBC_Shot::to_shot_props()`
+- `BcLibC.findApexShot`, `findMaxRangeShot`, `findZeroAngleShot`, `integrateShot`, `integrateAtShot` — preferred API; all physics conversion in C++
+- `README.md` rewritten to document the actual package API
+
+### Changed (**breaking** — requires updated bclibc ≥ next minor version)
+- `calculator.dart`: `Calculator._toBcShotProps()` replaced with thin field mapper `_toBcShot()` — Coriolis trig and atmosphere density computation removed from Dart; all physics conversion delegated to `BCLIBC_Shot::to_shot_props()` in C++
+- `bclibc_bindings.g.dart`: all native struct and enum type names renamed from `BC*` to `BCLIBCFFI_*` to match the `BCLIBCFFI_` function prefix:
+  - `BCConfig` → `BCLIBCFFI_Config`, `BCAtmosphere` → `BCLIBCFFI_Atmosphere`, `BCCoriolis` → `BCLIBCFFI_Coriolis`, `BCWind` → `BCLIBCFFI_Wind`, `BCDragPoint` → `BCLIBCFFI_DragPoint`
+  - `BCShotProps` → `BCLIBCFFI_ShotProps`, `BCShot` → `BCLIBCFFI_Shot`
+  - `BCTrajFlag` → `BCLIBCFFI_TrajFlag` (values `BCLIBCFFI_TRAJ_FLAG_*`), `BCTerminationReason` → `BCLIBCFFI_TerminationReason`, `BCBaseTrajInterpKey` → `BCLIBCFFI_BaseTrajInterpKey`, `BCIntegrationMethod` → `BCLIBCFFI_IntegrationMethod`
+  - `BCTrajectoryRequest` → `BCLIBCFFI_TrajectoryRequest`, `BCBaseTrajData` → `BCLIBCFFI_BaseTrajData`, `BCTrajectoryData` → `BCLIBCFFI_TrajectoryData`, `BCMaxRangeResult` → `BCLIBCFFI_MaxRangeResult`, `BCInterception` → `BCLIBCFFI_Interception`
+  - `BCLIBCFFIError` → `BCLIBCFFI_Error`, `BCLIBCFFIStatus` → `BCLIBCFFI_Status`
+- `BCLIBCFFI_Shot` struct updated: `drag_table: BCLIBCFFI_DragPoint*` replaced with separate `mach_data: Pointer<Double>` + `cd_data: Pointer<Double>` parallel arrays — matches `BCLIBC_Shot` C++ layout; `_FillNativeShot._fill` updated accordingly
+- `bclibc_ffi.dart`: all enum / native-type references updated to `BCLIBCFFI_*`; `BcShotProps` / old `BcLibC.*()` API retained for backwards compatibility
+- `external/bclibc` submodule: `583029b` — `BCLIBCFFI_*` rename + `BCLIBCFFI_Shot` separate arrays + `BCLIBCFFI_Error`/`BCLIBCFFI_Status`
+
 ## 0.0.1
 
-* TODO: Describe initial release.
+* Initial release.

--- a/packages/bclibc_ffi/README.md
+++ b/packages/bclibc_ffi/README.md
@@ -1,92 +1,114 @@
 # bclibc_ffi
 
-A new Flutter FFI plugin project.
+Dart FFI bindings for the [bclibc](https://github.com/ballistics-lab/bclibc) ballistics engine.
 
-## Getting Started
+## Overview
 
-This project is a starting point for a Flutter
-[FFI plugin](https://flutter.dev/to/ffi-package),
-a specialized package that includes native code directly invoked with Dart FFI.
+This package exposes `BcLibC`, a thin Dart wrapper around the `bclibc_ffi` shared library (`libbclibc_ffi.so` / `bclibc_ffi.dll` / `libbclibc_ffi.dylib`). It mirrors the WASM bindings API surface: `findApex`, `findMaxRange`, `findZeroAngle`, `integrate`, `integrateAt`.
 
-## Project structure
+## Quick start
 
-This template uses the following structure:
+```dart
+import 'package:bclibc_ffi/bclibc_ffi.dart';
 
-* `src`: Contains the native source code, and a CmakeFile.txt file for building
-  that source code into a dynamic library.
+final bc = BcLibC.open(); // loads the native library once
 
-* `lib`: Contains the Dart code that defines the API of the plugin, and which
-  calls into the native code using `dart:ffi`.
+final shot = BcShot(
+  bc: 0.295,
+  weightGrain: 168.0,
+  diameterInch: 0.308,
+  lengthInch: 1.22,
+  muzzleVelocityFps: 2750.0,
+  sightHeightFt: 0.1148,
+  twistInch: 10.0,
+  tempC: 15.0,
+  pressureHpa: 1013.25,
+  altitudeFt: 0.0,
+  dragTable: [BcDragPoint(0.0, 0.0), ...], // Mach / CD pairs
+  lookAngleRad: 0.0,
+  barrelElevationRad: 0.0,
+);
 
-* platform folders (`android`, `ios`, `windows`, etc.): Contains the build files
-  for building and bundling the native code library with the platform application.
+final hit = bc.integrateShot(
+  shot,
+  BcTrajectoryRequest(rangeLimitFt: 3000.0, rangeStepFt: 100.0),
+);
 
-## Building and bundling native code
-
-The `pubspec.yaml` specifies FFI plugins as follows:
-
-```yaml
-  plugin:
-    platforms:
-      some_platform:
-        ffiPlugin: true
+for (final pt in hit.trajectory) {
+  print('${pt.distanceFt} ft  ${pt.velocityFps} fps  ${pt.heightFt} ft');
+}
 ```
 
-This configuration invokes the native build for the various target platforms
-and bundles the binaries in Flutter applications using these FFI plugins.
+## API
 
-This can be combined with dartPluginClass, such as when FFI is used for the
-implementation of one platform in a federated plugin:
+### Input types
 
-```yaml
-  plugin:
-    implements: some_other_plugin
-    platforms:
-      some_platform:
-        dartPluginClass: SomeClass
-        ffiPlugin: true
+| Dart type | Description |
+|---|---|
+| `BcShot` | Preferred shot input (natural units). All physics conversion — atmosphere density, Coriolis trig, PCHIP drag curve, cant — is performed inside C++ via `BCLIBC_Shot::to_shot_props()`. |
+| `BcShotProps` | Legacy shot input (pre-computed `BcAtmosphere`/`BcCoriolis` structs). |
+| `BcTrajectoryRequest` | Step size, range limit, and `BCLIBCFFI_TrajFlag` filter bitmask. |
+| `BcConfig` | Solver knobs (step multiplier, accuracy, gravity constant, etc.). |
+| `BcDragPoint` | One Mach / CD entry for the drag table. |
+| `BcWind` | One wind segment (velocity, direction, distance bounds). |
+
+### Result types
+
+| Dart type | Description |
+|---|---|
+| `BcTrajectoryData` | One filtered trajectory record. |
+| `BcHitResult` | Full trajectory list + `BCLIBCFFI_TerminationReason`. |
+| `BcInterception` | Single interpolated point from `integrateAt`. |
+| `BcMaxRangeResult` | Max range (ft) + angle (rad) from `findMaxRange`. |
+
+### `BcLibC` methods
+
+| Method | Description |
+|---|---|
+| `findApexShot(BcShot)` | Highest point of trajectory |
+| `findMaxRangeShot(BcShot)` | Maximum range and corresponding angle |
+| `findZeroAngleShot(BcShot, distanceFt)` | Barrel elevation to zero at distance |
+| `integrateShot(BcShot, BcTrajectoryRequest)` | Full filtered trajectory |
+| `integrateAtShot(BcShot, key, value)` | Single interpolated point |
+| `getCorrection(distanceFt, offsetFt)` | Angular correction (rad) for offset |
+| `calculateEnergy(grains, fps)` | Kinetic energy (ft-lb) |
+| `calculateOgw(grains, fps)` | Optimal Game Weight |
+
+Legacy `BcShotProps`-based overloads (`findApex`, `findMaxRange`, etc.) are retained for backwards compatibility.
+
+### Enums
+
+| Dart enum | Description |
+|---|---|
+| `BCLIBCFFI_TrajFlag` | Trajectory filter flags (`BCLIBCFFI_TRAJ_FLAG_RANGE`, `BCLIBCFFI_TRAJ_FLAG_APEX`, …) |
+| `BCLIBCFFI_TerminationReason` | Why integration stopped |
+| `BCLIBCFFI_BaseTrajInterpKey` | Key field selector for `integrateAt` |
+| `BCLIBCFFI_IntegrationMethod` | `BCLIBCFFI_INTEGRATION_RK4` (default) or `BCLIBCFFI_INTEGRATION_EULER` |
+
+## Atmosphere and Coriolis
+
+When using `BcShot`:
+- Pass `pressureHpa: 0` for vacuum (zero drag).
+- Pass `latitudeDeg: double.nan` to disable Coriolis (default `BcShot` value).
+- Pass `azimuthDeg: double.nan` for flat-fire drift only.
+
+## Regenerating bindings
+
+After building a new version of `bclibc`:
+
+```bash
+dart run ffigen --config ffigen.yaml
 ```
 
-A plugin can have both FFI and method channels:
+The generated file is `lib/ffi/bclibc_bindings.g.dart`.
 
-```yaml
-  plugin:
-    platforms:
-      some_platform:
-        pluginClass: SomeName
-        ffiPlugin: true
-```
+## Native library
 
-The native build systems that are invoked by FFI (and method channel) plugins are:
+The shared library must be placed where the platform can find it, or the path set via the `BCLIBC_FFI_PATH` environment variable (useful during development/testing).
 
-* For Android: Gradle, which invokes the Android NDK for native builds.
-  * See the documentation in android/build.gradle.
-* For iOS and MacOS: Xcode, via CocoaPods.
-  * See the documentation in ios/bclibc_ffi.podspec.
-  * See the documentation in macos/bclibc_ffi.podspec.
-* For Linux and Windows: CMake.
-  * See the documentation in linux/CMakeLists.txt.
-  * See the documentation in windows/CMakeLists.txt.
-
-## Binding to native code
-
-To use the native code, bindings in Dart are needed.
-To avoid writing these by hand, they are generated from the header file
-(`src/bclibc_ffi.h`) by `package:ffigen`.
-Regenerate the bindings by running `dart run ffigen --config ffigen.yaml`.
-
-## Invoking native code
-
-Very short-running native functions can be directly invoked from any isolate.
-For example, see `sum` in `lib/bclibc_ffi.dart`.
-
-Longer-running functions should be invoked on a helper isolate to avoid
-dropping frames in Flutter applications.
-For example, see `sumAsync` in `lib/bclibc_ffi.dart`.
-
-## Flutter help
-
-For help getting started with Flutter, view our
-[online documentation](https://docs.flutter.dev), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
-
+| Platform | Library name |
+|---|---|
+| Linux | `libbclibc_ffi.so` |
+| Android | `libbclibc_ffi.so` |
+| macOS | `libbclibc_ffi.dylib` |
+| Windows | `bclibc_ffi.dll` |

--- a/packages/bclibc_ffi/lib/ffi/bclibc_bindings.g.dart
+++ b/packages/bclibc_ffi/lib/ffi/bclibc_bindings.g.dart
@@ -44,9 +44,9 @@ class BcLibCFFIBindings {
   /// Find the apex (highest point) of the trajectory.
   /// @return BCLIBCFFI_OK on success, error code otherwise (fills *err).
   int BCLIBCFFI_find_apex(
-    ffi.Pointer<BCShotProps> props,
-    ffi.Pointer<BCTrajectoryData> out,
-    ffi.Pointer<BCLIBCFFIError> err,
+    ffi.Pointer<BCLIBCFFI_ShotProps> props,
+    ffi.Pointer<BCLIBCFFI_TrajectoryData> out,
+    ffi.Pointer<BCLIBCFFI_Error> err,
   ) {
     return _BCLIBCFFI_find_apex(props, out, err);
   }
@@ -55,18 +55,18 @@ class BcLibCFFIBindings {
       _lookup<
         ffi.NativeFunction<
           ffi.Int32 Function(
-            ffi.Pointer<BCShotProps>,
-            ffi.Pointer<BCTrajectoryData>,
-            ffi.Pointer<BCLIBCFFIError>,
+            ffi.Pointer<BCLIBCFFI_ShotProps>,
+            ffi.Pointer<BCLIBCFFI_TrajectoryData>,
+            ffi.Pointer<BCLIBCFFI_Error>,
           )
         >
       >('BCLIBCFFI_find_apex');
   late final _BCLIBCFFI_find_apex =
       _BCLIBCFFI_find_apexPtr.asFunction<
         int Function(
-          ffi.Pointer<BCShotProps>,
-          ffi.Pointer<BCTrajectoryData>,
-          ffi.Pointer<BCLIBCFFIError>,
+          ffi.Pointer<BCLIBCFFI_ShotProps>,
+          ffi.Pointer<BCLIBCFFI_TrajectoryData>,
+          ffi.Pointer<BCLIBCFFI_Error>,
         )
       >();
 
@@ -74,11 +74,11 @@ class BcLibCFFIBindings {
   /// @param low_angle_deg   Lower search bound (degrees).
   /// @param high_angle_deg  Upper search bound (degrees).
   int BCLIBCFFI_find_max_range(
-    ffi.Pointer<BCShotProps> props,
+    ffi.Pointer<BCLIBCFFI_ShotProps> props,
     double low_angle_deg,
     double high_angle_deg,
-    ffi.Pointer<BCMaxRangeResult> out,
-    ffi.Pointer<BCLIBCFFIError> err,
+    ffi.Pointer<BCLIBCFFI_MaxRangeResult> out,
+    ffi.Pointer<BCLIBCFFI_Error> err,
   ) {
     return _BCLIBCFFI_find_max_range(
       props,
@@ -93,22 +93,22 @@ class BcLibCFFIBindings {
       _lookup<
         ffi.NativeFunction<
           ffi.Int32 Function(
-            ffi.Pointer<BCShotProps>,
+            ffi.Pointer<BCLIBCFFI_ShotProps>,
             ffi.Double,
             ffi.Double,
-            ffi.Pointer<BCMaxRangeResult>,
-            ffi.Pointer<BCLIBCFFIError>,
+            ffi.Pointer<BCLIBCFFI_MaxRangeResult>,
+            ffi.Pointer<BCLIBCFFI_Error>,
           )
         >
       >('BCLIBCFFI_find_max_range');
   late final _BCLIBCFFI_find_max_range =
       _BCLIBCFFI_find_max_rangePtr.asFunction<
         int Function(
-          ffi.Pointer<BCShotProps>,
+          ffi.Pointer<BCLIBCFFI_ShotProps>,
           double,
           double,
-          ffi.Pointer<BCMaxRangeResult>,
-          ffi.Pointer<BCLIBCFFIError>,
+          ffi.Pointer<BCLIBCFFI_MaxRangeResult>,
+          ffi.Pointer<BCLIBCFFI_Error>,
         )
       >();
 
@@ -116,10 +116,10 @@ class BcLibCFFIBindings {
   /// @param distance_ft     Slant distance to target (ft).
   /// @param out_angle_rad   Output: barrel elevation (radians).
   int BCLIBCFFI_find_zero_angle(
-    ffi.Pointer<BCShotProps> props,
+    ffi.Pointer<BCLIBCFFI_ShotProps> props,
     double distance_ft,
     ffi.Pointer<ffi.Double> out_angle_rad,
-    ffi.Pointer<BCLIBCFFIError> err,
+    ffi.Pointer<BCLIBCFFI_Error> err,
   ) {
     return _BCLIBCFFI_find_zero_angle(props, distance_ft, out_angle_rad, err);
   }
@@ -128,34 +128,34 @@ class BcLibCFFIBindings {
       _lookup<
         ffi.NativeFunction<
           ffi.Int32 Function(
-            ffi.Pointer<BCShotProps>,
+            ffi.Pointer<BCLIBCFFI_ShotProps>,
             ffi.Double,
             ffi.Pointer<ffi.Double>,
-            ffi.Pointer<BCLIBCFFIError>,
+            ffi.Pointer<BCLIBCFFI_Error>,
           )
         >
       >('BCLIBCFFI_find_zero_angle');
   late final _BCLIBCFFI_find_zero_angle =
       _BCLIBCFFI_find_zero_anglePtr.asFunction<
         int Function(
-          ffi.Pointer<BCShotProps>,
+          ffi.Pointer<BCLIBCFFI_ShotProps>,
           double,
           ffi.Pointer<ffi.Double>,
-          ffi.Pointer<BCLIBCFFIError>,
+          ffi.Pointer<BCLIBCFFI_Error>,
         )
       >();
 
   /// Integrate trajectory and return filtered records.
   ///
-  /// On success *out_records points to a heap-allocated BCTrajectoryData array
+  /// On success *out_records points to a heap-allocated BCLIBCFFI_TrajectoryData array
   /// of length *out_count.  Call BCLIBCFFI_free_trajectory() to release it.
   int BCLIBCFFI_integrate(
-    ffi.Pointer<BCShotProps> props,
-    ffi.Pointer<BCTrajectoryRequest> request,
-    ffi.Pointer<ffi.Pointer<BCTrajectoryData>> out_records,
+    ffi.Pointer<BCLIBCFFI_ShotProps> props,
+    ffi.Pointer<BCLIBCFFI_TrajectoryRequest> request,
+    ffi.Pointer<ffi.Pointer<BCLIBCFFI_TrajectoryData>> out_records,
     ffi.Pointer<ffi.Int32> out_count,
     ffi.Pointer<ffi.Int32> out_reason,
-    ffi.Pointer<BCLIBCFFIError> err,
+    ffi.Pointer<BCLIBCFFI_Error> err,
   ) {
     return _BCLIBCFFI_integrate(
       props,
@@ -171,51 +171,55 @@ class BcLibCFFIBindings {
       _lookup<
         ffi.NativeFunction<
           ffi.Int32 Function(
-            ffi.Pointer<BCShotProps>,
-            ffi.Pointer<BCTrajectoryRequest>,
-            ffi.Pointer<ffi.Pointer<BCTrajectoryData>>,
+            ffi.Pointer<BCLIBCFFI_ShotProps>,
+            ffi.Pointer<BCLIBCFFI_TrajectoryRequest>,
+            ffi.Pointer<ffi.Pointer<BCLIBCFFI_TrajectoryData>>,
             ffi.Pointer<ffi.Int32>,
             ffi.Pointer<ffi.Int32>,
-            ffi.Pointer<BCLIBCFFIError>,
+            ffi.Pointer<BCLIBCFFI_Error>,
           )
         >
       >('BCLIBCFFI_integrate');
   late final _BCLIBCFFI_integrate =
       _BCLIBCFFI_integratePtr.asFunction<
         int Function(
-          ffi.Pointer<BCShotProps>,
-          ffi.Pointer<BCTrajectoryRequest>,
-          ffi.Pointer<ffi.Pointer<BCTrajectoryData>>,
+          ffi.Pointer<BCLIBCFFI_ShotProps>,
+          ffi.Pointer<BCLIBCFFI_TrajectoryRequest>,
+          ffi.Pointer<ffi.Pointer<BCLIBCFFI_TrajectoryData>>,
           ffi.Pointer<ffi.Int32>,
           ffi.Pointer<ffi.Int32>,
-          ffi.Pointer<BCLIBCFFIError>,
+          ffi.Pointer<BCLIBCFFI_Error>,
         )
       >();
 
   /// Free a trajectory array allocated by BCLIBCFFI_integrate().
-  void BCLIBCFFI_free_trajectory(ffi.Pointer<BCTrajectoryData> records) {
+  void BCLIBCFFI_free_trajectory(
+    ffi.Pointer<BCLIBCFFI_TrajectoryData> records,
+  ) {
     return _BCLIBCFFI_free_trajectory(records);
   }
 
   late final _BCLIBCFFI_free_trajectoryPtr =
       _lookup<
-        ffi.NativeFunction<ffi.Void Function(ffi.Pointer<BCTrajectoryData>)>
+        ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<BCLIBCFFI_TrajectoryData>)
+        >
       >('BCLIBCFFI_free_trajectory');
   late final _BCLIBCFFI_free_trajectory =
       _BCLIBCFFI_free_trajectoryPtr.asFunction<
-        void Function(ffi.Pointer<BCTrajectoryData>)
+        void Function(ffi.Pointer<BCLIBCFFI_TrajectoryData>)
       >();
 
   /// Integrate and interpolate the single point where a key field reaches
   /// the target value.
-  /// @param key          BCBaseTrajInterpKey
+  /// @param key          BCLIBCFFI_BaseTrajInterpKey
   /// @param target_value Value the key field must reach.
   int BCLIBCFFI_integrate_at(
-    ffi.Pointer<BCShotProps> props,
+    ffi.Pointer<BCLIBCFFI_ShotProps> props,
     int key,
     double target_value,
-    ffi.Pointer<BCInterception> out,
-    ffi.Pointer<BCLIBCFFIError> err,
+    ffi.Pointer<BCLIBCFFI_Interception> out,
+    ffi.Pointer<BCLIBCFFI_Error> err,
   ) {
     return _BCLIBCFFI_integrate_at(props, key, target_value, out, err);
   }
@@ -224,22 +228,201 @@ class BcLibCFFIBindings {
       _lookup<
         ffi.NativeFunction<
           ffi.Int32 Function(
-            ffi.Pointer<BCShotProps>,
+            ffi.Pointer<BCLIBCFFI_ShotProps>,
             ffi.Int32,
             ffi.Double,
-            ffi.Pointer<BCInterception>,
-            ffi.Pointer<BCLIBCFFIError>,
+            ffi.Pointer<BCLIBCFFI_Interception>,
+            ffi.Pointer<BCLIBCFFI_Error>,
           )
         >
       >('BCLIBCFFI_integrate_at');
   late final _BCLIBCFFI_integrate_at =
       _BCLIBCFFI_integrate_atPtr.asFunction<
         int Function(
-          ffi.Pointer<BCShotProps>,
+          ffi.Pointer<BCLIBCFFI_ShotProps>,
           int,
           double,
-          ffi.Pointer<BCInterception>,
-          ffi.Pointer<BCLIBCFFIError>,
+          ffi.Pointer<BCLIBCFFI_Interception>,
+          ffi.Pointer<BCLIBCFFI_Error>,
+        )
+      >();
+
+  /// Find the apex of the trajectory.
+  /// All physics/unit conversion is performed inside C++ via BCLIBCFFI_Shot::to_shot_props().
+  int BCLIBCFFI_find_apex_shot(
+    ffi.Pointer<BCLIBCFFI_Shot> shot,
+    ffi.Pointer<BCLIBCFFI_TrajectoryData> out,
+    ffi.Pointer<BCLIBCFFI_Error> err,
+  ) {
+    return _BCLIBCFFI_find_apex_shot(shot, out, err);
+  }
+
+  late final _BCLIBCFFI_find_apex_shotPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Int32 Function(
+            ffi.Pointer<BCLIBCFFI_Shot>,
+            ffi.Pointer<BCLIBCFFI_TrajectoryData>,
+            ffi.Pointer<BCLIBCFFI_Error>,
+          )
+        >
+      >('BCLIBCFFI_find_apex_shot');
+  late final _BCLIBCFFI_find_apex_shot =
+      _BCLIBCFFI_find_apex_shotPtr.asFunction<
+        int Function(
+          ffi.Pointer<BCLIBCFFI_Shot>,
+          ffi.Pointer<BCLIBCFFI_TrajectoryData>,
+          ffi.Pointer<BCLIBCFFI_Error>,
+        )
+      >();
+
+  int BCLIBCFFI_find_max_range_shot(
+    ffi.Pointer<BCLIBCFFI_Shot> shot,
+    double low_angle_deg,
+    double high_angle_deg,
+    ffi.Pointer<BCLIBCFFI_MaxRangeResult> out,
+    ffi.Pointer<BCLIBCFFI_Error> err,
+  ) {
+    return _BCLIBCFFI_find_max_range_shot(
+      shot,
+      low_angle_deg,
+      high_angle_deg,
+      out,
+      err,
+    );
+  }
+
+  late final _BCLIBCFFI_find_max_range_shotPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Int32 Function(
+            ffi.Pointer<BCLIBCFFI_Shot>,
+            ffi.Double,
+            ffi.Double,
+            ffi.Pointer<BCLIBCFFI_MaxRangeResult>,
+            ffi.Pointer<BCLIBCFFI_Error>,
+          )
+        >
+      >('BCLIBCFFI_find_max_range_shot');
+  late final _BCLIBCFFI_find_max_range_shot =
+      _BCLIBCFFI_find_max_range_shotPtr.asFunction<
+        int Function(
+          ffi.Pointer<BCLIBCFFI_Shot>,
+          double,
+          double,
+          ffi.Pointer<BCLIBCFFI_MaxRangeResult>,
+          ffi.Pointer<BCLIBCFFI_Error>,
+        )
+      >();
+
+  int BCLIBCFFI_find_zero_angle_shot(
+    ffi.Pointer<BCLIBCFFI_Shot> shot,
+    double distance_ft,
+    ffi.Pointer<ffi.Double> out_angle_rad,
+    ffi.Pointer<BCLIBCFFI_Error> err,
+  ) {
+    return _BCLIBCFFI_find_zero_angle_shot(
+      shot,
+      distance_ft,
+      out_angle_rad,
+      err,
+    );
+  }
+
+  late final _BCLIBCFFI_find_zero_angle_shotPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Int32 Function(
+            ffi.Pointer<BCLIBCFFI_Shot>,
+            ffi.Double,
+            ffi.Pointer<ffi.Double>,
+            ffi.Pointer<BCLIBCFFI_Error>,
+          )
+        >
+      >('BCLIBCFFI_find_zero_angle_shot');
+  late final _BCLIBCFFI_find_zero_angle_shot =
+      _BCLIBCFFI_find_zero_angle_shotPtr.asFunction<
+        int Function(
+          ffi.Pointer<BCLIBCFFI_Shot>,
+          double,
+          ffi.Pointer<ffi.Double>,
+          ffi.Pointer<BCLIBCFFI_Error>,
+        )
+      >();
+
+  int BCLIBCFFI_integrate_shot(
+    ffi.Pointer<BCLIBCFFI_Shot> shot,
+    ffi.Pointer<BCLIBCFFI_TrajectoryRequest> request,
+    ffi.Pointer<ffi.Pointer<BCLIBCFFI_TrajectoryData>> out_records,
+    ffi.Pointer<ffi.Int32> out_count,
+    ffi.Pointer<ffi.Int32> out_reason,
+    ffi.Pointer<BCLIBCFFI_Error> err,
+  ) {
+    return _BCLIBCFFI_integrate_shot(
+      shot,
+      request,
+      out_records,
+      out_count,
+      out_reason,
+      err,
+    );
+  }
+
+  late final _BCLIBCFFI_integrate_shotPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Int32 Function(
+            ffi.Pointer<BCLIBCFFI_Shot>,
+            ffi.Pointer<BCLIBCFFI_TrajectoryRequest>,
+            ffi.Pointer<ffi.Pointer<BCLIBCFFI_TrajectoryData>>,
+            ffi.Pointer<ffi.Int32>,
+            ffi.Pointer<ffi.Int32>,
+            ffi.Pointer<BCLIBCFFI_Error>,
+          )
+        >
+      >('BCLIBCFFI_integrate_shot');
+  late final _BCLIBCFFI_integrate_shot =
+      _BCLIBCFFI_integrate_shotPtr.asFunction<
+        int Function(
+          ffi.Pointer<BCLIBCFFI_Shot>,
+          ffi.Pointer<BCLIBCFFI_TrajectoryRequest>,
+          ffi.Pointer<ffi.Pointer<BCLIBCFFI_TrajectoryData>>,
+          ffi.Pointer<ffi.Int32>,
+          ffi.Pointer<ffi.Int32>,
+          ffi.Pointer<BCLIBCFFI_Error>,
+        )
+      >();
+
+  int BCLIBCFFI_integrate_at_shot(
+    ffi.Pointer<BCLIBCFFI_Shot> shot,
+    int key,
+    double target_value,
+    ffi.Pointer<BCLIBCFFI_Interception> out,
+    ffi.Pointer<BCLIBCFFI_Error> err,
+  ) {
+    return _BCLIBCFFI_integrate_at_shot(shot, key, target_value, out, err);
+  }
+
+  late final _BCLIBCFFI_integrate_at_shotPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Int32 Function(
+            ffi.Pointer<BCLIBCFFI_Shot>,
+            ffi.Int32,
+            ffi.Double,
+            ffi.Pointer<BCLIBCFFI_Interception>,
+            ffi.Pointer<BCLIBCFFI_Error>,
+          )
+        >
+      >('BCLIBCFFI_integrate_at_shot');
+  late final _BCLIBCFFI_integrate_at_shot =
+      _BCLIBCFFI_integrate_at_shotPtr.asFunction<
+        int Function(
+          ffi.Pointer<BCLIBCFFI_Shot>,
+          int,
+          double,
+          ffi.Pointer<BCLIBCFFI_Interception>,
+          ffi.Pointer<BCLIBCFFI_Error>,
         )
       >();
 
@@ -290,7 +473,7 @@ class BcLibCFFIBindings {
       _BCLIBCFFI_calculate_ogwPtr.asFunction<double Function(double, double)>();
 }
 
-enum BCLIBCFFIStatus {
+enum BCLIBCFFI_Status {
   BCLIBCFFI_OK(0),
   BCLIBCFFI_ERR_SOLVER_RUNTIME(1),
   BCLIBCFFI_ERR_OUT_OF_RANGE(2),
@@ -299,22 +482,22 @@ enum BCLIBCFFIStatus {
   BCLIBCFFI_ERR_GENERIC(5);
 
   final int value;
-  const BCLIBCFFIStatus(this.value);
+  const BCLIBCFFI_Status(this.value);
 
-  static BCLIBCFFIStatus fromValue(int value) => switch (value) {
+  static BCLIBCFFI_Status fromValue(int value) => switch (value) {
     0 => BCLIBCFFI_OK,
     1 => BCLIBCFFI_ERR_SOLVER_RUNTIME,
     2 => BCLIBCFFI_ERR_OUT_OF_RANGE,
     3 => BCLIBCFFI_ERR_ZERO_FINDING,
     4 => BCLIBCFFI_ERR_INTERCEPTION,
     5 => BCLIBCFFI_ERR_GENERIC,
-    _ => throw ArgumentError('Unknown value for BCLIBCFFIStatus: $value'),
+    _ => throw ArgumentError('Unknown value for BCLIBCFFI_Status: $value'),
   };
 }
 
 /// Error output struct – filled by every function on failure.
-final class BCLIBCFFIError extends ffi.Struct {
-  /// < BCLIBCFFIStatus
+final class BCLIBCFFI_Error extends ffi.Struct {
+  /// < BCLIBCFFI_Status
   @ffi.Int32()
   external int code;
 
@@ -339,98 +522,104 @@ final class BCLIBCFFIError extends ffi.Struct {
   external int i32_0;
 }
 
-enum BCTrajFlag {
-  BC_TRAJ_FLAG_NONE(0),
-  BC_TRAJ_FLAG_ZERO_UP(1),
-  BC_TRAJ_FLAG_ZERO_DOWN(2),
-  BC_TRAJ_FLAG_ZERO(3),
-  BC_TRAJ_FLAG_MACH(4),
-  BC_TRAJ_FLAG_RANGE(8),
-  BC_TRAJ_FLAG_APEX(16),
-  BC_TRAJ_FLAG_ALL(31),
-  BC_TRAJ_FLAG_MRT(32);
+enum BCLIBCFFI_TrajFlag {
+  BCLIBCFFI_TRAJ_FLAG_NONE(0),
+  BCLIBCFFI_TRAJ_FLAG_ZERO_UP(1),
+  BCLIBCFFI_TRAJ_FLAG_ZERO_DOWN(2),
+  BCLIBCFFI_TRAJ_FLAG_ZERO(3),
+  BCLIBCFFI_TRAJ_FLAG_MACH(4),
+  BCLIBCFFI_TRAJ_FLAG_RANGE(8),
+  BCLIBCFFI_TRAJ_FLAG_APEX(16),
+  BCLIBCFFI_TRAJ_FLAG_ALL(31),
+  BCLIBCFFI_TRAJ_FLAG_MRT(32);
 
   final int value;
-  const BCTrajFlag(this.value);
+  const BCLIBCFFI_TrajFlag(this.value);
 
-  static BCTrajFlag fromValue(int value) => switch (value) {
-    0 => BC_TRAJ_FLAG_NONE,
-    1 => BC_TRAJ_FLAG_ZERO_UP,
-    2 => BC_TRAJ_FLAG_ZERO_DOWN,
-    3 => BC_TRAJ_FLAG_ZERO,
-    4 => BC_TRAJ_FLAG_MACH,
-    8 => BC_TRAJ_FLAG_RANGE,
-    16 => BC_TRAJ_FLAG_APEX,
-    31 => BC_TRAJ_FLAG_ALL,
-    32 => BC_TRAJ_FLAG_MRT,
-    _ => throw ArgumentError('Unknown value for BCTrajFlag: $value'),
+  static BCLIBCFFI_TrajFlag fromValue(int value) => switch (value) {
+    0 => BCLIBCFFI_TRAJ_FLAG_NONE,
+    1 => BCLIBCFFI_TRAJ_FLAG_ZERO_UP,
+    2 => BCLIBCFFI_TRAJ_FLAG_ZERO_DOWN,
+    3 => BCLIBCFFI_TRAJ_FLAG_ZERO,
+    4 => BCLIBCFFI_TRAJ_FLAG_MACH,
+    8 => BCLIBCFFI_TRAJ_FLAG_RANGE,
+    16 => BCLIBCFFI_TRAJ_FLAG_APEX,
+    31 => BCLIBCFFI_TRAJ_FLAG_ALL,
+    32 => BCLIBCFFI_TRAJ_FLAG_MRT,
+    _ => throw ArgumentError('Unknown value for BCLIBCFFI_TrajFlag: $value'),
   };
 }
 
-enum BCTerminationReason {
-  BC_TERM_NO_TERMINATE(0),
-  BC_TERM_TARGET_RANGE_REACHED(1),
-  BC_TERM_MINIMUM_VELOCITY_REACHED(2),
-  BC_TERM_MAXIMUM_DROP_REACHED(3),
-  BC_TERM_MINIMUM_ALTITUDE_REACHED(4),
-  BC_TERM_HANDLER_REQUESTED_STOP(5);
+enum BCLIBCFFI_TerminationReason {
+  BCLIBCFFI_TERM_NO_TERMINATE(0),
+  BCLIBCFFI_TERM_TARGET_RANGE_REACHED(1),
+  BCLIBCFFI_TERM_MINIMUM_VELOCITY_REACHED(2),
+  BCLIBCFFI_TERM_MAXIMUM_DROP_REACHED(3),
+  BCLIBCFFI_TERM_MINIMUM_ALTITUDE_REACHED(4),
+  BCLIBCFFI_TERM_HANDLER_REQUESTED_STOP(5);
 
   final int value;
-  const BCTerminationReason(this.value);
+  const BCLIBCFFI_TerminationReason(this.value);
 
-  static BCTerminationReason fromValue(int value) => switch (value) {
-    0 => BC_TERM_NO_TERMINATE,
-    1 => BC_TERM_TARGET_RANGE_REACHED,
-    2 => BC_TERM_MINIMUM_VELOCITY_REACHED,
-    3 => BC_TERM_MAXIMUM_DROP_REACHED,
-    4 => BC_TERM_MINIMUM_ALTITUDE_REACHED,
-    5 => BC_TERM_HANDLER_REQUESTED_STOP,
-    _ => throw ArgumentError('Unknown value for BCTerminationReason: $value'),
+  static BCLIBCFFI_TerminationReason fromValue(int value) => switch (value) {
+    0 => BCLIBCFFI_TERM_NO_TERMINATE,
+    1 => BCLIBCFFI_TERM_TARGET_RANGE_REACHED,
+    2 => BCLIBCFFI_TERM_MINIMUM_VELOCITY_REACHED,
+    3 => BCLIBCFFI_TERM_MAXIMUM_DROP_REACHED,
+    4 => BCLIBCFFI_TERM_MINIMUM_ALTITUDE_REACHED,
+    5 => BCLIBCFFI_TERM_HANDLER_REQUESTED_STOP,
+    _ => throw ArgumentError(
+      'Unknown value for BCLIBCFFI_TerminationReason: $value',
+    ),
   };
 }
 
 /// Interpolation key for BCLIBC_BaseTrajData fields.
-enum BCBaseTrajInterpKey {
-  BC_INTERP_KEY_TIME(0),
-  BC_INTERP_KEY_MACH(1),
-  BC_INTERP_KEY_POS_X(2),
-  BC_INTERP_KEY_POS_Y(3),
-  BC_INTERP_KEY_POS_Z(4),
-  BC_INTERP_KEY_VEL_X(5),
-  BC_INTERP_KEY_VEL_Y(6),
-  BC_INTERP_KEY_VEL_Z(7);
+enum BCLIBCFFI_BaseTrajInterpKey {
+  BCLIBCFFI_INTERP_KEY_TIME(0),
+  BCLIBCFFI_INTERP_KEY_MACH(1),
+  BCLIBCFFI_INTERP_KEY_POS_X(2),
+  BCLIBCFFI_INTERP_KEY_POS_Y(3),
+  BCLIBCFFI_INTERP_KEY_POS_Z(4),
+  BCLIBCFFI_INTERP_KEY_VEL_X(5),
+  BCLIBCFFI_INTERP_KEY_VEL_Y(6),
+  BCLIBCFFI_INTERP_KEY_VEL_Z(7);
 
   final int value;
-  const BCBaseTrajInterpKey(this.value);
+  const BCLIBCFFI_BaseTrajInterpKey(this.value);
 
-  static BCBaseTrajInterpKey fromValue(int value) => switch (value) {
-    0 => BC_INTERP_KEY_TIME,
-    1 => BC_INTERP_KEY_MACH,
-    2 => BC_INTERP_KEY_POS_X,
-    3 => BC_INTERP_KEY_POS_Y,
-    4 => BC_INTERP_KEY_POS_Z,
-    5 => BC_INTERP_KEY_VEL_X,
-    6 => BC_INTERP_KEY_VEL_Y,
-    7 => BC_INTERP_KEY_VEL_Z,
-    _ => throw ArgumentError('Unknown value for BCBaseTrajInterpKey: $value'),
+  static BCLIBCFFI_BaseTrajInterpKey fromValue(int value) => switch (value) {
+    0 => BCLIBCFFI_INTERP_KEY_TIME,
+    1 => BCLIBCFFI_INTERP_KEY_MACH,
+    2 => BCLIBCFFI_INTERP_KEY_POS_X,
+    3 => BCLIBCFFI_INTERP_KEY_POS_Y,
+    4 => BCLIBCFFI_INTERP_KEY_POS_Z,
+    5 => BCLIBCFFI_INTERP_KEY_VEL_X,
+    6 => BCLIBCFFI_INTERP_KEY_VEL_Y,
+    7 => BCLIBCFFI_INTERP_KEY_VEL_Z,
+    _ => throw ArgumentError(
+      'Unknown value for BCLIBCFFI_BaseTrajInterpKey: $value',
+    ),
   };
 }
 
-enum BCIntegrationMethod {
-  BC_INTEGRATION_RK4(0),
-  BC_INTEGRATION_EULER(1);
+enum BCLIBCFFI_IntegrationMethod {
+  BCLIBCFFI_INTEGRATION_RK4(0),
+  BCLIBCFFI_INTEGRATION_EULER(1);
 
   final int value;
-  const BCIntegrationMethod(this.value);
+  const BCLIBCFFI_IntegrationMethod(this.value);
 
-  static BCIntegrationMethod fromValue(int value) => switch (value) {
-    0 => BC_INTEGRATION_RK4,
-    1 => BC_INTEGRATION_EULER,
-    _ => throw ArgumentError('Unknown value for BCIntegrationMethod: $value'),
+  static BCLIBCFFI_IntegrationMethod fromValue(int value) => switch (value) {
+    0 => BCLIBCFFI_INTEGRATION_RK4,
+    1 => BCLIBCFFI_INTEGRATION_EULER,
+    _ => throw ArgumentError(
+      'Unknown value for BCLIBCFFI_IntegrationMethod: $value',
+    ),
   };
 }
 
-final class BCConfig extends ffi.Struct {
+final class BCLIBCFFI_Config extends ffi.Struct {
   @ffi.Double()
   external double cStepMultiplier;
 
@@ -453,7 +642,7 @@ final class BCConfig extends ffi.Struct {
   external double cMinimumAltitude;
 }
 
-final class BCAtmosphere extends ffi.Struct {
+final class BCLIBCFFI_Atmosphere extends ffi.Struct {
   /// < Temperature at base altitude (°F)
   @ffi.Double()
   external double t0;
@@ -479,7 +668,7 @@ final class BCAtmosphere extends ffi.Struct {
   external double cLowestTempC;
 }
 
-final class BCCoriolis extends ffi.Struct {
+final class BCLIBCFFI_Coriolis extends ffi.Struct {
   @ffi.Double()
   external double sin_lat;
 
@@ -512,7 +701,7 @@ final class BCCoriolis extends ffi.Struct {
   external double muzzle_velocity_fps;
 }
 
-final class BCWind extends ffi.Struct {
+final class BCLIBCFFI_Wind extends ffi.Struct {
   @ffi.Double()
   external double velocity_fps;
 
@@ -527,7 +716,7 @@ final class BCWind extends ffi.Struct {
   external double max_distance_ft;
 }
 
-final class BCDragPoint extends ffi.Struct {
+final class BCLIBCFFI_DragPoint extends ffi.Struct {
   @ffi.Double()
   external double Mach;
 
@@ -536,7 +725,7 @@ final class BCDragPoint extends ffi.Struct {
 }
 
 /// Flat shot properties passed to every engine function.
-final class BCShotProps extends ffi.Struct {
+final class BCLIBCFFI_ShotProps extends ffi.Struct {
   @ffi.Double()
   external double bc;
 
@@ -573,31 +762,121 @@ final class BCShotProps extends ffi.Struct {
   @ffi.Double()
   external double muzzle_velocity_fps;
 
-  external BCAtmosphere atmo;
+  external BCLIBCFFI_Atmosphere atmo;
 
-  external BCCoriolis coriolis;
+  external BCLIBCFFI_Coriolis coriolis;
 
-  external BCConfig config;
+  external BCLIBCFFI_Config config;
 
   @ffi.UnsignedInt()
   external int methodAsInt;
 
-  BCIntegrationMethod get method => BCIntegrationMethod.fromValue(methodAsInt);
+  BCLIBCFFI_IntegrationMethod get method =>
+      BCLIBCFFI_IntegrationMethod.fromValue(methodAsInt);
 
   /// Drag table – pointer must remain valid for the duration of the call.
-  external ffi.Pointer<BCDragPoint> drag_table;
+  external ffi.Pointer<BCLIBCFFI_DragPoint> drag_table;
 
   @ffi.Int32()
   external int drag_table_count;
 
   /// Wind list – pointer must remain valid for the duration of the call.
-  external ffi.Pointer<BCWind> winds;
+  external ffi.Pointer<BCLIBCFFI_Wind> winds;
 
   @ffi.Int32()
   external int wind_count;
 }
 
-final class BCTrajectoryRequest extends ffi.Struct {
+/// User-facing shot descriptor in natural units.
+///
+/// Preferred input for BCLIBCFFI_*_shot() functions.  All physics conversions
+/// (CIPM-2007 atmosphere density, Coriolis trig, PCHIP drag curve, cant sin/cos)
+/// are performed inside C++ by BCLIBC_Shot::to_shot_props().
+///
+/// latitude_deg / azimuth_deg: pass NaN to disable Coriolis / flat-fire-only.
+/// pressure_hpa == 0          : vacuum (zero drag).
+///
+/// All pointers must remain valid for the duration of the call.
+/// Drag table is passed as two parallel arrays (mach_data / cd_data) matching
+/// the BCLIBC_Shot layout — no interleaved struct needed.
+final class BCLIBCFFI_Shot extends ffi.Struct {
+  @ffi.Double()
+  external double bc;
+
+  @ffi.Double()
+  external double weight_grain;
+
+  @ffi.Double()
+  external double diameter_inch;
+
+  @ffi.Double()
+  external double length_inch;
+
+  @ffi.Double()
+  external double muzzle_velocity_fps;
+
+  @ffi.Double()
+  external double sight_height_ft;
+
+  @ffi.Double()
+  external double twist_inch;
+
+  @ffi.Double()
+  external double temp_c;
+
+  /// < 0 = vacuum
+  @ffi.Double()
+  external double pressure_hpa;
+
+  @ffi.Double()
+  external double altitude_ft;
+
+  /// < 0.0 – 1.0
+  @ffi.Double()
+  external double humidity;
+
+  /// Parallel Mach / CD arrays – must remain valid for the duration of the call.
+  external ffi.Pointer<ffi.Double> mach_data;
+
+  external ffi.Pointer<ffi.Double> cd_data;
+
+  @ffi.Int32()
+  external int drag_table_size;
+
+  /// Wind list – must remain valid for the duration of the call.
+  external ffi.Pointer<BCLIBCFFI_Wind> winds;
+
+  @ffi.Int32()
+  external int wind_count;
+
+  @ffi.Double()
+  external double look_angle_rad;
+
+  @ffi.Double()
+  external double barrel_elevation_rad;
+
+  @ffi.Double()
+  external double barrel_azimuth_rad;
+
+  @ffi.Double()
+  external double cant_angle_rad;
+
+  @ffi.Double()
+  external double latitude_deg;
+
+  @ffi.Double()
+  external double azimuth_deg;
+
+  external BCLIBCFFI_Config config;
+
+  @ffi.UnsignedInt()
+  external int methodAsInt;
+
+  BCLIBCFFI_IntegrationMethod get method =>
+      BCLIBCFFI_IntegrationMethod.fromValue(methodAsInt);
+}
+
+final class BCLIBCFFI_TrajectoryRequest extends ffi.Struct {
   @ffi.Double()
   external double range_limit_ft;
 
@@ -607,12 +886,12 @@ final class BCTrajectoryRequest extends ffi.Struct {
   @ffi.Double()
   external double time_step;
 
-  /// < BCTrajFlag bitmask
+  /// < BCLIBCFFI_TrajFlag bitmask
   @ffi.Int32()
   external int filter_flags;
 }
 
-final class BCBaseTrajData extends ffi.Struct {
+final class BCLIBCFFI_BaseTrajData extends ffi.Struct {
   @ffi.Double()
   external double time;
 
@@ -644,7 +923,7 @@ final class BCBaseTrajData extends ffi.Struct {
   external double mach;
 }
 
-final class BCTrajectoryData extends ffi.Struct {
+final class BCLIBCFFI_TrajectoryData extends ffi.Struct {
   @ffi.Double()
   external double time;
 
@@ -690,12 +969,12 @@ final class BCTrajectoryData extends ffi.Struct {
   @ffi.Double()
   external double ogw_lb;
 
-  /// < BCTrajFlag
+  /// < BCLIBCFFI_TrajFlag
   @ffi.Int32()
   external int flag;
 }
 
-final class BCMaxRangeResult extends ffi.Struct {
+final class BCLIBCFFI_MaxRangeResult extends ffi.Struct {
   @ffi.Double()
   external double max_range_ft;
 
@@ -703,8 +982,8 @@ final class BCMaxRangeResult extends ffi.Struct {
   external double angle_at_max_rad;
 }
 
-final class BCInterception extends ffi.Struct {
-  external BCBaseTrajData raw_data;
+final class BCLIBCFFI_Interception extends ffi.Struct {
+  external BCLIBCFFI_BaseTrajData raw_data;
 
-  external BCTrajectoryData full_data;
+  external BCLIBCFFI_TrajectoryData full_data;
 }

--- a/packages/bclibc_ffi/lib/ffi/bclibc_ffi.dart
+++ b/packages/bclibc_ffi/lib/ffi/bclibc_ffi.dart
@@ -1,12 +1,12 @@
 // ignore_for_file: dangling_library_doc_comments
 /// Thin Dart wrapper over the bclibc C FFI layer.
 ///
-/// API mirrors the WASM bindings:
-///   findApex, findMaxRange, findZeroAngle, integrate, integrateAt
+/// API:
+///   findApexShot, findMaxRangeShot, findZeroAngleShot, integrateShot, integrateAtShot
 ///
 /// Usage:
 ///   final bc = BcLibC.open();
-///   final hit = bc.integrate(props, request);
+///   final hit = bc.integrateShot(shot, request);
 
 import 'dart:ffi' as ffi;
 import 'dart:io';
@@ -21,9 +21,15 @@ import 'bclibc_bindings.g.dart';
 
 ffi.DynamicLibrary _openLibrary() {
   String lib(String name) {
-    // During development / dart test: check local cmake build dir first.
     final env = Platform.environment['BCLIBC_FFI_PATH'];
     if (env != null && env.isNotEmpty) return env;
+    // Prefer the Flutter-built bundle so tests use the same binary as the app.
+    // Falls back to the standalone cmake build (make build-bclibc) for CI /
+    // fresh checkouts where flutter build hasn't run yet.
+    for (final mode in const ['debug', 'profile', 'release']) {
+      final p = 'build/linux/x64/$mode/bundle/lib/$name';
+      if (File(p).existsSync()) return p;
+    }
     final devPath = 'build/bclibc/$name';
     if (File(devPath).existsSync()) return devPath;
     return name; // bundled app (RPATH / system lookup)
@@ -41,7 +47,7 @@ ffi.DynamicLibrary _openLibrary() {
 }
 
 // ============================================================================
-// Dart-side value types (mirrors WASM JS plain-objects)
+// Dart-side value types
 // ============================================================================
 
 class BcConfig {
@@ -61,44 +67,6 @@ class BcConfig {
     this.maxIterations = 50,
     this.gravityConstant = -32.17405,
     this.minimumAltitude = -1000.0,
-  });
-}
-
-class BcAtmosphere {
-  final double t0;
-  final double a0;
-  final double p0;
-  final double mach;
-  final double densityRatio;
-  final double cLowestTempC;
-
-  const BcAtmosphere({
-    required this.t0,
-    required this.a0,
-    required this.p0,
-    required this.mach,
-    required this.densityRatio,
-    required this.cLowestTempC,
-  });
-}
-
-class BcCoriolis {
-  final double sinLat, cosLat, sinAz, cosAz;
-  final double rangeEast, rangeNorth, crossEast, crossNorth;
-  final bool flatFireOnly;
-  final double muzzleVelocityFps;
-
-  const BcCoriolis({
-    this.sinLat = 0,
-    this.cosLat = 1,
-    this.sinAz = 0,
-    this.cosAz = 1,
-    this.rangeEast = 0,
-    this.rangeNorth = 0,
-    this.crossEast = 0,
-    this.crossNorth = 0,
-    this.flatFireOnly = true,
-    this.muzzleVelocityFps = 0,
   });
 }
 
@@ -122,46 +90,63 @@ class BcDragPoint {
   const BcDragPoint(this.mach, this.cd);
 }
 
-class BcShotProps {
+/// Shot descriptor in natural units.
+///
+/// All physics conversions (atmosphere density, Coriolis trig, PCHIP drag
+/// curve, cant sin/cos) are performed inside C++ by BCLIBC_Shot::to_shot_props().
+///
+/// [latitudeDeg] / [azimuthDeg]: pass double.nan to disable Coriolis (flat-fire only).
+/// [pressureHpa] == 0: vacuum (zero drag).
+class BcShot {
   final double bc;
-  final double lookAngleRad;
-  final double twistInch;
-  final double lengthInch;
-  final double diameterInch;
   final double weightGrain;
-  final double barrelElevationRad;
-  final double barrelAzimuthRad;
-  final double sightHeightFt;
-  final double cantAngleRad;
-  final double alt0Ft;
+  final double diameterInch;
+  final double lengthInch;
   final double muzzleVelocityFps;
-  final BcAtmosphere atmo;
-  final BcCoriolis coriolis;
-  final BcConfig config;
+  final double sightHeightFt;
+  final double twistInch;
 
-  final BCIntegrationMethod method;
+  final double tempC;
+  final double pressureHpa;
+  final double altitudeFt;
+  final double humidity;
+
   final List<BcDragPoint> dragTable;
   final List<BcWind> winds;
 
-  const BcShotProps({
+  final double lookAngleRad;
+  final double barrelElevationRad;
+  final double barrelAzimuthRad;
+  final double cantAngleRad;
+
+  final double latitudeDeg;
+  final double azimuthDeg;
+
+  final BcConfig config;
+  final BCLIBCFFI_IntegrationMethod method;
+
+  const BcShot({
     required this.bc,
-    required this.lookAngleRad,
-    required this.twistInch,
-    required this.lengthInch,
-    required this.diameterInch,
     required this.weightGrain,
-    required this.barrelElevationRad,
-    required this.barrelAzimuthRad,
-    required this.sightHeightFt,
-    this.cantAngleRad = 0.0,
-    required this.alt0Ft,
+    required this.diameterInch,
+    required this.lengthInch,
     required this.muzzleVelocityFps,
-    required this.atmo,
-    required this.coriolis,
-    this.config = const BcConfig(),
-    this.method = BCIntegrationMethod.BC_INTEGRATION_RK4,
+    required this.sightHeightFt,
+    required this.twistInch,
+    required this.tempC,
+    required this.pressureHpa,
+    required this.altitudeFt,
+    this.humidity = 0.0,
     required this.dragTable,
     this.winds = const [],
+    required this.lookAngleRad,
+    required this.barrelElevationRad,
+    this.barrelAzimuthRad = 0.0,
+    this.cantAngleRad = 0.0,
+    this.latitudeDeg = double.nan,
+    this.azimuthDeg = double.nan,
+    this.config = const BcConfig(),
+    this.method = BCLIBCFFI_IntegrationMethod.BCLIBCFFI_INTEGRATION_RK4,
   });
 }
 
@@ -170,14 +155,14 @@ class BcTrajectoryRequest {
   final double rangeStepFt;
   final double timeStep;
 
-  /// BCTrajFlag bitmask (may combine multiple flags via bitwise OR)
+  /// BCLIBCFFI_TrajFlag bitmask (may combine multiple flags via bitwise OR)
   final int filterFlags;
 
   const BcTrajectoryRequest({
     required this.rangeLimitFt,
     required this.rangeStepFt,
     this.timeStep = 0.0,
-    this.filterFlags = 8, // BCTrajFlag.BC_TRAJ_FLAG_RANGE
+    this.filterFlags = 8, // BCLIBCFFI_TrajFlag.BCLIBCFFI_TRAJ_FLAG_RANGE
   });
 }
 
@@ -192,7 +177,7 @@ class BcTrajectoryData {
   final double slantDistanceFt, angleRad;
   final double densityRatio, drag;
   final double energyFtLb, ogwLb;
-  final int flag; // BCTrajFlag
+  final int flag; // BCLIBCFFI_TrajFlag
 
   const BcTrajectoryData({
     required this.time,
@@ -213,24 +198,25 @@ class BcTrajectoryData {
     required this.flag,
   });
 
-  factory BcTrajectoryData._fromNative(BCTrajectoryData s) => BcTrajectoryData(
-    time: s.time,
-    distanceFt: s.distance_ft,
-    velocityFps: s.velocity_fps,
-    mach: s.mach,
-    heightFt: s.height_ft,
-    slantHeightFt: s.slant_height_ft,
-    dropAngleRad: s.drop_angle_rad,
-    windageFt: s.windage_ft,
-    windageAngleRad: s.windage_angle_rad,
-    slantDistanceFt: s.slant_distance_ft,
-    angleRad: s.angle_rad,
-    densityRatio: s.density_ratio,
-    drag: s.drag,
-    energyFtLb: s.energy_ft_lb,
-    ogwLb: s.ogw_lb,
-    flag: s.flag,
-  );
+  factory BcTrajectoryData._fromNative(BCLIBCFFI_TrajectoryData s) =>
+      BcTrajectoryData(
+        time: s.time,
+        distanceFt: s.distance_ft,
+        velocityFps: s.velocity_fps,
+        mach: s.mach,
+        heightFt: s.height_ft,
+        slantHeightFt: s.slant_height_ft,
+        dropAngleRad: s.drop_angle_rad,
+        windageFt: s.windage_ft,
+        windageAngleRad: s.windage_angle_rad,
+        slantDistanceFt: s.slant_distance_ft,
+        angleRad: s.angle_rad,
+        densityRatio: s.density_ratio,
+        drag: s.drag,
+        energyFtLb: s.energy_ft_lb,
+        ogwLb: s.ogw_lb,
+        flag: s.flag,
+      );
 }
 
 class BcBaseTrajData {
@@ -246,16 +232,17 @@ class BcBaseTrajData {
     required this.mach,
   });
 
-  factory BcBaseTrajData._fromNative(BCBaseTrajData s) => BcBaseTrajData(
-    time: s.time,
-    px: s.px,
-    py: s.py,
-    pz: s.pz,
-    vx: s.vx,
-    vy: s.vy,
-    vz: s.vz,
-    mach: s.mach,
-  );
+  factory BcBaseTrajData._fromNative(BCLIBCFFI_BaseTrajData s) =>
+      BcBaseTrajData(
+        time: s.time,
+        px: s.px,
+        py: s.py,
+        pz: s.pz,
+        vx: s.vx,
+        vy: s.vy,
+        vz: s.vz,
+        mach: s.mach,
+      );
 }
 
 class BcMaxRangeResult {
@@ -266,7 +253,7 @@ class BcMaxRangeResult {
 
 class BcHitResult {
   final List<BcTrajectoryData> trajectory;
-  final BCTerminationReason reason;
+  final BCLIBCFFI_TerminationReason reason;
   const BcHitResult(this.trajectory, this.reason);
 }
 
@@ -281,7 +268,7 @@ class BcInterception {
 // ============================================================================
 
 class BcException implements Exception {
-  final int code; // BCFFIStatus
+  final int code; // BCLIBCFFI_Status
   final String message;
   // OutOfRange extras
   final double? requestedDistanceFt, maxRangeFt, lookAngleRad;
@@ -315,9 +302,9 @@ String _charArrayToString(ffi.Array<ffi.Char> arr, int maxLen) {
   return String.fromCharCodes(codes);
 }
 
-Never _throwFromError(BCLIBCFFIError err) {
+Never _throwFromError(BCLIBCFFI_Error err) {
   final msg = _charArrayToString(err.message, 512);
-  if (err.code == BCLIBCFFIStatus.BCLIBCFFI_ERR_OUT_OF_RANGE.value) {
+  if (err.code == BCLIBCFFI_Status.BCLIBCFFI_ERR_OUT_OF_RANGE.value) {
     throw BcException(
       code: err.code,
       message: msg,
@@ -326,7 +313,7 @@ Never _throwFromError(BCLIBCFFIError err) {
       lookAngleRad: err.f64_2,
     );
   }
-  if (err.code == BCLIBCFFIStatus.BCLIBCFFI_ERR_ZERO_FINDING.value) {
+  if (err.code == BCLIBCFFI_Status.BCLIBCFFI_ERR_ZERO_FINDING.value) {
     throw BcException(
       code: err.code,
       message: msg,
@@ -342,39 +329,26 @@ Never _throwFromError(BCLIBCFFIError err) {
 // Native struct fill helper
 // ============================================================================
 
-extension _FillNative on BcShotProps {
-  void _fill(BCShotProps p, Arena arena) {
+extension _FillNativeShot on BcShot {
+  void _fill(BCLIBCFFI_Shot p, Arena arena) {
     p.bc = bc;
-    p.look_angle_rad = lookAngleRad;
-    p.twist_inch = twistInch;
-    p.length_inch = lengthInch;
-    p.diameter_inch = diameterInch;
     p.weight_grain = weightGrain;
+    p.diameter_inch = diameterInch;
+    p.length_inch = lengthInch;
+    p.muzzle_velocity_fps = muzzleVelocityFps;
+    p.sight_height_ft = sightHeightFt;
+    p.twist_inch = twistInch;
+    p.temp_c = tempC;
+    p.pressure_hpa = pressureHpa;
+    p.altitude_ft = altitudeFt;
+    p.humidity = humidity;
+    p.look_angle_rad = lookAngleRad;
     p.barrel_elevation_rad = barrelElevationRad;
     p.barrel_azimuth_rad = barrelAzimuthRad;
-    p.sight_height_ft = sightHeightFt;
     p.cant_angle_rad = cantAngleRad;
-    p.alt0_ft = alt0Ft;
-    p.muzzle_velocity_fps = muzzleVelocityFps;
+    p.latitude_deg = latitudeDeg;
+    p.azimuth_deg = azimuthDeg;
     p.methodAsInt = method.value;
-
-    p.atmo.t0 = atmo.t0;
-    p.atmo.a0 = atmo.a0;
-    p.atmo.p0 = atmo.p0;
-    p.atmo.mach = atmo.mach;
-    p.atmo.density_ratio = atmo.densityRatio;
-    p.atmo.cLowestTempC = atmo.cLowestTempC;
-
-    p.coriolis.sin_lat = coriolis.sinLat;
-    p.coriolis.cos_lat = coriolis.cosLat;
-    p.coriolis.sin_az = coriolis.sinAz;
-    p.coriolis.cos_az = coriolis.cosAz;
-    p.coriolis.range_east = coriolis.rangeEast;
-    p.coriolis.range_north = coriolis.rangeNorth;
-    p.coriolis.cross_east = coriolis.crossEast;
-    p.coriolis.cross_north = coriolis.crossNorth;
-    p.coriolis.flat_fire_only = coriolis.flatFireOnly ? 1 : 0;
-    p.coriolis.muzzle_velocity_fps = coriolis.muzzleVelocityFps;
 
     p.config.cStepMultiplier = config.stepMultiplier;
     p.config.cZeroFindingAccuracy = config.zeroFindingAccuracy;
@@ -384,19 +358,27 @@ extension _FillNative on BcShotProps {
     p.config.cGravityConstant = config.gravityConstant;
     p.config.cMinimumAltitude = config.minimumAltitude;
 
-    final dt = arena<BCDragPoint>(dragTable.length);
-    for (var i = 0; i < dragTable.length; i++) {
-      dt[i].Mach = dragTable[i].mach;
-      dt[i].CD = dragTable[i].cd;
+    if (dragTable.isEmpty) {
+      p.mach_data = ffi.nullptr;
+      p.cd_data = ffi.nullptr;
+      p.drag_table_size = 0;
+    } else {
+      final mach = arena<ffi.Double>(dragTable.length);
+      final cd = arena<ffi.Double>(dragTable.length);
+      for (var i = 0; i < dragTable.length; i++) {
+        mach[i] = dragTable[i].mach;
+        cd[i] = dragTable[i].cd;
+      }
+      p.mach_data = mach;
+      p.cd_data = cd;
+      p.drag_table_size = dragTable.length;
     }
-    p.drag_table = dt;
-    p.drag_table_count = dragTable.length;
 
     if (winds.isEmpty) {
       p.winds = ffi.nullptr;
       p.wind_count = 0;
     } else {
-      final ws = arena<BCWind>(winds.length);
+      final ws = arena<BCLIBCFFI_Wind>(winds.length);
       for (var i = 0; i < winds.length; i++) {
         ws[i].velocity_fps = winds[i].velocityFps;
         ws[i].direction_from_rad = winds[i].directionFromRad;
@@ -421,26 +403,39 @@ class BcLibC {
   /// Open the native library. Call once per isolate.
   factory BcLibC.open() => BcLibC._(BcLibCFFIBindings(_openLibrary()));
 
-  BcTrajectoryData findApex(BcShotProps props) => using((arena) {
-    final p = arena<BCShotProps>();
-    final out = arena<BCTrajectoryData>();
-    final err = arena<BCLIBCFFIError>();
-    props._fill(p.ref, arena);
-    final st = _b.BCLIBCFFI_find_apex(p, out, err);
+  // ── Utility functions ──────────────────────────────────────────────────────
+
+  double getCorrection(double distanceFt, double offsetFt) =>
+      _b.BCLIBCFFI_get_correction(distanceFt, offsetFt);
+
+  double calculateEnergy(double bulletWeightGrain, double velocityFps) =>
+      _b.BCLIBCFFI_calculate_energy(bulletWeightGrain, velocityFps);
+
+  double calculateOgw(double bulletWeightGrain, double velocityFps) =>
+      _b.BCLIBCFFI_calculate_ogw(bulletWeightGrain, velocityFps);
+
+  // ── BcShot-based API (all physics conversion in C++) ──────────────────────
+
+  BcTrajectoryData findApexShot(BcShot shot) => using((arena) {
+    final p = arena<BCLIBCFFI_Shot>();
+    final out = arena<BCLIBCFFI_TrajectoryData>();
+    final err = arena<BCLIBCFFI_Error>();
+    shot._fill(p.ref, arena);
+    final st = _b.BCLIBCFFI_find_apex_shot(p, out, err);
     if (st != 0) _throwFromError(err.ref);
     return BcTrajectoryData._fromNative(out.ref);
   });
 
-  BcMaxRangeResult findMaxRange(
-    BcShotProps props, {
+  BcMaxRangeResult findMaxRangeShot(
+    BcShot shot, {
     double lowAngleDeg = 0.0,
     double highAngleDeg = 45.0,
   }) => using((arena) {
-    final p = arena<BCShotProps>();
-    final out = arena<BCMaxRangeResult>();
-    final err = arena<BCLIBCFFIError>();
-    props._fill(p.ref, arena);
-    final st = _b.BCLIBCFFI_find_max_range(
+    final p = arena<BCLIBCFFI_Shot>();
+    final out = arena<BCLIBCFFI_MaxRangeResult>();
+    final err = arena<BCLIBCFFI_Error>();
+    shot._fill(p.ref, arena);
+    final st = _b.BCLIBCFFI_find_max_range_shot(
       p,
       lowAngleDeg,
       highAngleDeg,
@@ -451,71 +446,71 @@ class BcLibC {
     return BcMaxRangeResult(out.ref.max_range_ft, out.ref.angle_at_max_rad);
   });
 
-  double findZeroAngle(BcShotProps props, double distanceFt) => using((arena) {
-    final p = arena<BCShotProps>();
+  double findZeroAngleShot(BcShot shot, double distanceFt) => using((arena) {
+    final p = arena<BCLIBCFFI_Shot>();
     final outAngle = arena<ffi.Double>();
-    final err = arena<BCLIBCFFIError>();
-    props._fill(p.ref, arena);
-    final st = _b.BCLIBCFFI_find_zero_angle(p, distanceFt, outAngle, err);
+    final err = arena<BCLIBCFFI_Error>();
+    shot._fill(p.ref, arena);
+    final st = _b.BCLIBCFFI_find_zero_angle_shot(p, distanceFt, outAngle, err);
     if (st != 0) _throwFromError(err.ref);
     return outAngle.value;
   });
 
-  BcHitResult integrate(BcShotProps props, BcTrajectoryRequest request) =>
-      using((arena) {
-        final p = arena<BCShotProps>();
-        final req = arena<BCTrajectoryRequest>();
-        final pPtr = arena<ffi.Pointer<BCTrajectoryData>>();
-        final pCount = arena<ffi.Int32>();
-        final pReason = arena<ffi.Int32>();
-        final err = arena<BCLIBCFFIError>();
+  BcHitResult integrateShot(BcShot shot, BcTrajectoryRequest request) => using((
+    arena,
+  ) {
+    final p = arena<BCLIBCFFI_Shot>();
+    final req = arena<BCLIBCFFI_TrajectoryRequest>();
+    final pPtr = arena<ffi.Pointer<BCLIBCFFI_TrajectoryData>>();
+    final pCount = arena<ffi.Int32>();
+    final pReason = arena<ffi.Int32>();
+    final err = arena<BCLIBCFFI_Error>();
 
-        props._fill(p.ref, arena);
-        req.ref.range_limit_ft = request.rangeLimitFt;
-        req.ref.range_step_ft = request.rangeStepFt;
-        req.ref.time_step = request.timeStep;
-        req.ref.filter_flags = request.filterFlags;
+    shot._fill(p.ref, arena);
+    req.ref.range_limit_ft = request.rangeLimitFt;
+    req.ref.range_step_ft = request.rangeStepFt;
+    req.ref.time_step = request.timeStep;
+    req.ref.filter_flags = request.filterFlags;
 
-        final st = _b.BCLIBCFFI_integrate(p, req, pPtr, pCount, pReason, err);
-        if (st != 0) _throwFromError(err.ref);
+    final st = _b.BCLIBCFFI_integrate_shot(p, req, pPtr, pCount, pReason, err);
+    if (st != 0) _throwFromError(err.ref);
 
-        final count = pCount.value;
-        final rawPtr = pPtr.value;
-        final records = List<BcTrajectoryData>.generate(
-          count,
-          (i) => BcTrajectoryData._fromNative(rawPtr[i]),
-        );
-        if (count > 0) _b.BCLIBCFFI_free_trajectory(rawPtr);
+    final count = pCount.value;
+    final rawPtr = pPtr.value;
+    try {
+      final records = List<BcTrajectoryData>.generate(
+        count,
+        (i) => BcTrajectoryData._fromNative(rawPtr[i]),
+      );
+      return BcHitResult(
+        records,
+        BCLIBCFFI_TerminationReason.fromValue(pReason.value),
+      );
+    } finally {
+      if (count > 0) _b.BCLIBCFFI_free_trajectory(rawPtr);
+    }
+  });
 
-        return BcHitResult(
-          records,
-          BCTerminationReason.fromValue(pReason.value),
-        );
-      });
-
-  BcInterception integrateAt(
-    BcShotProps props,
-    BCBaseTrajInterpKey key,
+  BcInterception integrateAtShot(
+    BcShot shot,
+    BCLIBCFFI_BaseTrajInterpKey key,
     double targetValue,
   ) => using((arena) {
-    final p = arena<BCShotProps>();
-    final out = arena<BCInterception>();
-    final err = arena<BCLIBCFFIError>();
-    props._fill(p.ref, arena);
-    final st = _b.BCLIBCFFI_integrate_at(p, key.value, targetValue, out, err);
+    final p = arena<BCLIBCFFI_Shot>();
+    final out = arena<BCLIBCFFI_Interception>();
+    final err = arena<BCLIBCFFI_Error>();
+    shot._fill(p.ref, arena);
+    final st = _b.BCLIBCFFI_integrate_at_shot(
+      p,
+      key.value,
+      targetValue,
+      out,
+      err,
+    );
     if (st != 0) _throwFromError(err.ref);
     return BcInterception(
       BcBaseTrajData._fromNative(out.ref.raw_data),
       BcTrajectoryData._fromNative(out.ref.full_data),
     );
   });
-
-  double getCorrection(double distanceFt, double offsetFt) =>
-      _b.BCLIBCFFI_get_correction(distanceFt, offsetFt);
-
-  double calculateEnergy(double bulletWeightGrain, double velocityFps) =>
-      _b.BCLIBCFFI_calculate_energy(bulletWeightGrain, velocityFps);
-
-  double calculateOgw(double bulletWeightGrain, double velocityFps) =>
-      _b.BCLIBCFFI_calculate_ogw(bulletWeightGrain, velocityFps);
 }

--- a/packages/bclibc_ffi/lib/src/calculator.dart
+++ b/packages/bclibc_ffi/lib/src/calculator.dart
@@ -9,8 +9,6 @@
 //   calc.setWeaponZero(shot, Distance.meter(100));
 //   final result = calc.fire(shot: shot, trajectoryRange: Distance.meter(1000));
 
-import 'dart:math' as math;
-
 import 'package:bclibc_ffi/ffi/bclibc_bindings.g.dart';
 import 'package:bclibc_ffi/ffi/bclibc_ffi.dart';
 import 'package:bclibc_ffi/src/conditions.dart';
@@ -46,13 +44,13 @@ const BcConfig defaultConfig = BcConfig(
 // ---------------------------------------------------------------------------
 
 class Calculator {
-  final BCIntegrationMethod method;
+  final BCLIBCFFI_IntegrationMethod method;
   final BcConfig config;
 
   late final BcLibC _engine;
 
   Calculator({
-    this.method = BCIntegrationMethod.BC_INTEGRATION_RK4,
+    this.method = BCLIBCFFI_IntegrationMethod.BCLIBCFFI_INTEGRATION_RK4,
     BcConfig? config,
   }) : config = config ?? defaultConfig {
     _engine = BcLibC.open();
@@ -64,8 +62,8 @@ class Calculator {
   /// a target at [targetDistance].
   Angular barrelElevationForTarget(Shot shot, Distance targetDistance) {
     final distFt = _toFeet(targetDistance);
-    final props = _toBcShotProps(shot);
-    final totalRad = _engine.findZeroAngle(props, distFt);
+    final bcShot = _toBcShot(shot);
+    final totalRad = _engine.findZeroAngleShot(bcShot, distFt);
     return Angular(totalRad - shot.lookAngle.in_(Unit.radian), Unit.radian);
   }
 
@@ -91,7 +89,7 @@ class Calculator {
     required Distance trajectoryRange,
     Distance? trajectoryStep,
     double timeStep = 0.0,
-    int filterFlags = 8, // BCTrajFlag.BC_TRAJ_FLAG_RANGE
+    int filterFlags = 8, // BCLIBCFFI_TrajFlag.BCLIBCFFI_TRAJ_FLAG_RANGE
     bool raiseRangeError = true,
   }) {
     final rangeFt = _toFeet(trajectoryRange);
@@ -106,7 +104,7 @@ class Calculator {
 
     late BcHitResult bcResult;
     try {
-      bcResult = _engine.integrate(_toBcShotProps(shot), request);
+      bcResult = _engine.integrateShot(_toBcShot(shot), request);
     } on BcException catch (e) {
       if (raiseRangeError) rethrow;
       return HitResult(shot, [], filterFlags: filterFlags, error: e);
@@ -120,44 +118,41 @@ class Calculator {
 
   static double _toFeet(Distance d) => d.in_(Unit.foot);
 
-  /// Converts [Shot] + calculator settings to the flat C struct expected by BcLibC.
-  BcShotProps _toBcShotProps(Shot shot) {
+  /// Thin field mapper: copies [Shot] fields into [BcShot].
+  /// All physics/unit conversions (atmosphere density, Coriolis trig,
+  /// PCHIP drag curve, cant sin/cos) are performed inside C++ via
+  /// BCLIBC_Shot::to_shot_props().
+  BcShot _toBcShot(Shot shot) {
     final mvFps = shot.ammo
         .getVelocityForTemp(shot.atmo.powderTemp)
         .in_(Unit.fps);
 
-    return BcShotProps(
+    return BcShot(
       bc: shot.ammo.dm.bc,
-      lookAngleRad: shot.lookAngle.in_(Unit.radian),
-      twistInch: shot.weapon.twist.in_(Unit.inch),
-      lengthInch: shot.ammo.dm.length.in_(Unit.inch),
-      diameterInch: shot.ammo.dm.diameter.in_(Unit.inch),
       weightGrain: shot.ammo.dm.weight.in_(Unit.grain),
-      barrelElevationRad: shot.barrelElevation.in_(Unit.radian),
-      barrelAzimuthRad: shot.barrelAzimuth.in_(Unit.radian),
-      sightHeightFt: shot.weapon.sightHeight.in_(Unit.foot),
-      cantAngleRad: shot.cantAngle.in_(Unit.radian),
-      alt0Ft: shot.atmo.altitude.in_(Unit.foot),
+      diameterInch: shot.ammo.dm.diameter.in_(Unit.inch),
+      lengthInch: shot.ammo.dm.length.in_(Unit.inch),
       muzzleVelocityFps: mvFps,
-      atmo: _toAtmo(shot.atmo),
-      coriolis: _toCoriolis(shot, mvFps),
-      config: config,
-      method: method,
+      sightHeightFt: shot.weapon.sightHeight.in_(Unit.foot),
+      twistInch: shot.weapon.twist.in_(Unit.inch),
+      tempC: shot.atmo.temperature.in_(Unit.celsius),
+      pressureHpa: shot.atmo.pressure.in_(Unit.hPa),
+      altitudeFt: shot.atmo.altitude.in_(Unit.foot),
+      humidity: shot.atmo.humidity,
       dragTable: shot.ammo.dm.dragTable
           .map((p) => BcDragPoint(p.mach, p.cd))
           .toList(),
       winds: shot.winds.map(_toWind).toList(),
+      lookAngleRad: shot.lookAngle.in_(Unit.radian),
+      barrelElevationRad: shot.barrelElevation.in_(Unit.radian),
+      barrelAzimuthRad: shot.barrelAzimuth.in_(Unit.radian),
+      cantAngleRad: shot.cantAngle.in_(Unit.radian),
+      latitudeDeg: shot.latitudeDeg ?? double.nan,
+      azimuthDeg: shot.azimuthDeg ?? double.nan,
+      config: config,
+      method: method,
     );
   }
-
-  static BcAtmosphere _toAtmo(Atmo a) => BcAtmosphere(
-    t0: a.temperature.in_(Unit.celsius),
-    a0: a.altitude.in_(Unit.foot),
-    p0: a.pressure.in_(Unit.hPa),
-    mach: a.mach.in_(Unit.fps),
-    densityRatio: a.densityRatio,
-    cLowestTempC: Atmo.cLowestTempC,
-  );
 
   static BcWind _toWind(Wind w) => BcWind(
     velocityFps: w.velocity.in_(Unit.fps),
@@ -165,47 +160,6 @@ class Calculator {
     untilDistanceFt: w.untilDistance.in_(Unit.foot),
     maxDistanceFt: Wind.maxDistanceFeet,
   );
-
-  /// Mirrors the TypeScript Coriolis constructor logic.
-  static BcCoriolis _toCoriolis(Shot shot, double mvFps) {
-    final lat = shot.latitudeDeg;
-    if (lat == null) {
-      // No Coriolis
-      return BcCoriolis(muzzleVelocityFps: mvFps);
-    }
-
-    final latRad = lat * math.pi / 180.0;
-    final sinLat = math.sin(latRad);
-    final cosLat = math.cos(latRad);
-
-    final az = shot.azimuthDeg;
-    if (az == null) {
-      // Flat-fire approximation
-      return BcCoriolis(
-        sinLat: sinLat,
-        cosLat: cosLat,
-        flatFireOnly: true,
-        muzzleVelocityFps: mvFps,
-      );
-    }
-
-    // Full 3D Coriolis
-    final azRad = az * math.pi / 180.0;
-    final sinAz = math.sin(azRad);
-    final cosAz = math.cos(azRad);
-    return BcCoriolis(
-      sinLat: sinLat,
-      cosLat: cosLat,
-      sinAz: sinAz,
-      cosAz: cosAz,
-      rangeEast: sinAz,
-      rangeNorth: cosAz,
-      crossEast: cosAz,
-      crossNorth: -sinAz,
-      flatFireOnly: false,
-      muzzleVelocityFps: mvFps,
-    );
-  }
 
   // ── Result conversion ──────────────────────────────────────────────────────
 

--- a/packages/bclibc_ffi/pubspec.yaml
+++ b/packages/bclibc_ffi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bclibc_ffi
 description: "A new Flutter FFI plugin project."
-version: 0.0.1
+version: 0.1.0
 homepage:
 
 environment:

--- a/packages/reticle_gen/lib/reticle_gen.dart
+++ b/packages/reticle_gen/lib/reticle_gen.dart
@@ -258,22 +258,25 @@ class MilReticleSVGCanvas {
     final double minX = -milWidth / 2;
     final double minY = -milHeight / 2;
 
-    _svgElement = XmlElement(XmlName('svg'), [
-      XmlAttribute(XmlName('xmlns'), 'http://www.w3.org/2000/svg'),
-      XmlAttribute(XmlName('width'), _fmtNum(milWidth * factor)),
-      XmlAttribute(XmlName('height'), _fmtNum(milHeight * factor)),
+    _svgElement = XmlElement(XmlName.parts('svg'), [
+      XmlAttribute(XmlName.parts('xmlns'), 'http://www.w3.org/2000/svg'),
+      XmlAttribute(XmlName.parts('width'), _fmtNum(milWidth * factor)),
+      XmlAttribute(XmlName.parts('height'), _fmtNum(milHeight * factor)),
       XmlAttribute(
-        XmlName('viewBox'),
+        XmlName.parts('viewBox'),
         '${_fmtNum(minX)} ${_fmtNum(minY)} ${_fmtNum(milWidth)} ${_fmtNum(milHeight)}',
       ),
-      XmlAttribute(XmlName('shape-rendering'), 'geometricPrecision'),
+      XmlAttribute(XmlName.parts('shape-rendering'), 'geometricPrecision'),
     ]);
     _idCounters.clear();
     _clipCounter = 0;
 
     if (unitScale != 1.0) {
-      final scaleGroup = XmlElement(XmlName('g'), [
-        XmlAttribute(XmlName('transform'), 'scale(${_fmtNum(unitScale)})'),
+      final scaleGroup = XmlElement(XmlName.parts('g'), [
+        XmlAttribute(
+          XmlName.parts('transform'),
+          'scale(${_fmtNum(unitScale)})',
+        ),
       ]);
       _svgElement.children.add(scaleGroup);
       _contentRoot = scaleGroup;
@@ -314,21 +317,21 @@ class MilReticleSVGCanvas {
     }
 
     _target.children.add(
-      XmlElement(XmlName('line'), [
-        XmlAttribute(XmlName('id'), nextId('line')),
-        XmlAttribute(XmlName('x1'), _fmtNum(x1)),
-        XmlAttribute(XmlName('y1'), _fmtNum(y1)),
-        XmlAttribute(XmlName('x2'), _fmtNum(x2)),
-        XmlAttribute(XmlName('y2'), _fmtNum(y2)),
-        XmlAttribute(XmlName('stroke'), stroke),
-        XmlAttribute(XmlName('stroke-width'), _fmtNum(strokeWidth)),
+      XmlElement(XmlName.parts('line'), [
+        XmlAttribute(XmlName.parts('id'), nextId('line')),
+        XmlAttribute(XmlName.parts('x1'), _fmtNum(x1)),
+        XmlAttribute(XmlName.parts('y1'), _fmtNum(y1)),
+        XmlAttribute(XmlName.parts('x2'), _fmtNum(x2)),
+        XmlAttribute(XmlName.parts('y2'), _fmtNum(y2)),
+        XmlAttribute(XmlName.parts('stroke'), stroke),
+        XmlAttribute(XmlName.parts('stroke-width'), _fmtNum(strokeWidth)),
         if (strokeLineJoin != null)
-          XmlAttribute(XmlName('stroke-linejoin'), strokeLineJoin),
+          XmlAttribute(XmlName.parts('stroke-linejoin'), strokeLineJoin),
         if (strokeLineCap != null)
-          XmlAttribute(XmlName('stroke-linecap'), strokeLineCap),
+          XmlAttribute(XmlName.parts('stroke-linecap'), strokeLineCap),
         if (actualDash != null && actualGap != null)
           XmlAttribute(
-            XmlName('stroke-dasharray'),
+            XmlName.parts('stroke-dasharray'),
             '${_fmtNum(actualDash)} ${_fmtNum(actualGap)}',
           ),
       ]),
@@ -345,16 +348,16 @@ class MilReticleSVGCanvas {
     double? strokeWidth,
   }) {
     _target.children.add(
-      XmlElement(XmlName('rect'), [
-        XmlAttribute(XmlName('id'), nextId('rect')),
-        XmlAttribute(XmlName('x'), _fmtNum(x)),
-        XmlAttribute(XmlName('y'), _fmtNum(y)),
-        XmlAttribute(XmlName('width'), _fmtNum(w)),
-        XmlAttribute(XmlName('height'), _fmtNum(h)),
-        XmlAttribute(XmlName('fill'), fill),
-        if (stroke != null) XmlAttribute(XmlName('stroke'), stroke),
+      XmlElement(XmlName.parts('rect'), [
+        XmlAttribute(XmlName.parts('id'), nextId('rect')),
+        XmlAttribute(XmlName.parts('x'), _fmtNum(x)),
+        XmlAttribute(XmlName.parts('y'), _fmtNum(y)),
+        XmlAttribute(XmlName.parts('width'), _fmtNum(w)),
+        XmlAttribute(XmlName.parts('height'), _fmtNum(h)),
+        XmlAttribute(XmlName.parts('fill'), fill),
+        if (stroke != null) XmlAttribute(XmlName.parts('stroke'), stroke),
         if (strokeWidth != null)
-          XmlAttribute(XmlName('stroke-width'), _fmtNum(strokeWidth)),
+          XmlAttribute(XmlName.parts('stroke-width'), _fmtNum(strokeWidth)),
       ]),
     );
   }
@@ -398,15 +401,15 @@ class MilReticleSVGCanvas {
         break;
       case CirclesBatchMode.none:
         _target.children.add(
-          XmlElement(XmlName('circle'), [
-            XmlAttribute(XmlName('id'), nextId('circle')),
-            XmlAttribute(XmlName('cx'), _fmtNum(cx)),
-            XmlAttribute(XmlName('cy'), _fmtNum(cy)),
-            XmlAttribute(XmlName('r'), _fmtNum(r)),
-            XmlAttribute(XmlName('fill'), fill ?? "none"),
-            if (stroke != null) XmlAttribute(XmlName('stroke'), stroke),
+          XmlElement(XmlName.parts('circle'), [
+            XmlAttribute(XmlName.parts('id'), nextId('circle')),
+            XmlAttribute(XmlName.parts('cx'), _fmtNum(cx)),
+            XmlAttribute(XmlName.parts('cy'), _fmtNum(cy)),
+            XmlAttribute(XmlName.parts('r'), _fmtNum(r)),
+            XmlAttribute(XmlName.parts('fill'), fill ?? "none"),
+            if (stroke != null) XmlAttribute(XmlName.parts('stroke'), stroke),
             if (strokeWidth != null)
-              XmlAttribute(XmlName('stroke-width'), _fmtNum(strokeWidth)),
+              XmlAttribute(XmlName.parts('stroke-width'), _fmtNum(strokeWidth)),
           ]),
         );
     }
@@ -421,17 +424,17 @@ class MilReticleSVGCanvas {
     String? strokeLineCap = 'miter',
   }) {
     _target.children.add(
-      XmlElement(XmlName('path'), [
-        XmlAttribute(XmlName('id'), nextId('path')),
-        XmlAttribute(XmlName('d'), d),
-        if (fill != null) XmlAttribute(XmlName('fill'), fill),
-        if (stroke != null) XmlAttribute(XmlName('stroke'), stroke),
+      XmlElement(XmlName.parts('path'), [
+        XmlAttribute(XmlName.parts('id'), nextId('path')),
+        XmlAttribute(XmlName.parts('d'), d),
+        if (fill != null) XmlAttribute(XmlName.parts('fill'), fill),
+        if (stroke != null) XmlAttribute(XmlName.parts('stroke'), stroke),
         if (strokeWidth != null)
-          XmlAttribute(XmlName('stroke-width'), _fmtNum(strokeWidth)),
+          XmlAttribute(XmlName.parts('stroke-width'), _fmtNum(strokeWidth)),
         if (strokeLineJoin != null)
-          XmlAttribute(XmlName('stroke-linejoin'), strokeLineJoin),
+          XmlAttribute(XmlName.parts('stroke-linejoin'), strokeLineJoin),
         if (strokeLineCap != null)
-          XmlAttribute(XmlName('stroke-linecap'), strokeLineCap),
+          XmlAttribute(XmlName.parts('stroke-linecap'), strokeLineCap),
       ]),
     );
   }
@@ -446,17 +449,17 @@ class MilReticleSVGCanvas {
   }) {
     _target.children.add(
       XmlElement(
-        XmlName('text'),
+        XmlName.parts('text'),
         [
-          XmlAttribute(XmlName('id'), nextId('text')),
-          XmlAttribute(XmlName('x'), _fmtNum(x)),
-          XmlAttribute(XmlName('y'), _fmtNum(y)),
-          XmlAttribute(XmlName('fill'), fill),
+          XmlAttribute(XmlName.parts('id'), nextId('text')),
+          XmlAttribute(XmlName.parts('x'), _fmtNum(x)),
+          XmlAttribute(XmlName.parts('y'), _fmtNum(y)),
+          XmlAttribute(XmlName.parts('fill'), fill),
           XmlAttribute(
-            XmlName('font-size'),
+            XmlName.parts('font-size'),
             _fmtNum(fontSize / _capHeightRatio),
           ),
-          XmlAttribute(XmlName('text-anchor'), textAnchor),
+          XmlAttribute(XmlName.parts('text-anchor'), textAnchor),
         ],
         [XmlText(content)],
       ),
@@ -524,8 +527,8 @@ class MilReticleSVGCanvas {
   }) {
     final clipId = 'clip${_clipCounter++}';
 
-    final clipPathEl = XmlElement(XmlName('clipPath'), [
-      XmlAttribute(XmlName('id'), clipId),
+    final clipPathEl = XmlElement(XmlName.parts('clipPath'), [
+      XmlAttribute(XmlName.parts('id'), clipId),
     ]);
     final prevTarget = _target;
     _target = clipPathEl;
@@ -533,9 +536,9 @@ class MilReticleSVGCanvas {
     _target = prevTarget;
     _contentRoot.children.add(clipPathEl);
 
-    final groupEl = XmlElement(XmlName('g'), [
-      XmlAttribute(XmlName('id'), nextId('clipgroup')),
-      XmlAttribute(XmlName('clip-path'), 'url(#$clipId)'),
+    final groupEl = XmlElement(XmlName.parts('g'), [
+      XmlAttribute(XmlName.parts('id'), nextId('clipgroup')),
+      XmlAttribute(XmlName.parts('clip-path'), 'url(#$clipId)'),
     ]);
     _target = groupEl;
     draw(this);

--- a/packages/reticle_gen/pubspec.lock
+++ b/packages/reticle_gen/pubspec.lock
@@ -389,10 +389,10 @@ packages:
     dependency: "direct main"
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:

--- a/packages/reticle_gen/pubspec.yaml
+++ b/packages/reticle_gen/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 # Add regular dependencies here.
 dependencies:
   args: ^2.7.0
-  xml: ^6.6.1
+  xml: ^7.0.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       path: "packages/bclibc_ffi"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -654,10 +654,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.1"
+    version: "9.0.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -862,18 +862,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.4"
+    version: "12.0.2"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "6.1.0"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,9 +49,9 @@ dependencies:
   window_manager: ^0.5.1
   flutter_riverpod: ^3.3.1
   uuid: ^4.0.0
-  package_info_plus: ^8.0.0
+  package_info_plus: ^9.0.0
   path_provider: ^2.1.0
-  share_plus: ^10.0.0
+  share_plus: ^12.0.0
   url_launcher: ^6.3.0
   go_router: ^17.1.0
   sticky_headers: ^0.3.0
@@ -80,7 +80,7 @@ dev_dependencies:
   flutter_native_splash: ^2.4.4
   flutter_launcher_icons: ^0.14.3
   msix: ^3.16.13
-  flutpak: ^0.4.0-beta.4
+  flutpak: ^0.4.0-rc.2
   custom_lint: ^0.8.1
 
 # For information on the generic Dart part of this file, see the
@@ -173,11 +173,13 @@ flutpak:
   patches:
     - package: objectbox_flutter_libs
       path: flatpak/patches/objectbox_flutter_libs/CMakeLists.txt.patch
-      strip_trailing_cr: true
+      strip-trailing-cr: true
 
-  manifest:
-    app_id: io.github.o_murphy.ebalistyka
-    icons:
+  modules:
+    - flatpak/modules/bclibc.yml
+    - flatpak/modules/objectbox-c.yml
+
+  icons:
     - size: 16x16
       path: app/share/icons/hicolor/16x16/apps/io.github.o_murphy.ebalistyka.png
     - size: 32x32
@@ -190,30 +192,11 @@ flutpak:
       path: app/share/icons/hicolor/256x256/apps/io.github.o_murphy.ebalistyka.png
     - size: 512x512
       path: app/share/icons/hicolor/512x512/apps/io.github.o_murphy.ebalistyka.png
-    runtime_version: "25.08"
-    sdk_extensions:
+
+  manifest:
+    app-id: io.github.o_murphy.ebalistyka
+    runtime-version: "25.08"
+    sdk-extensions:
       - org.freedesktop.Sdk.Extension.llvm20
-    finish_args:
-      - --share=ipc
-      - --socket=fallback-x11
-      - --socket=wayland
-      - --device=dri
-    extra_modules:
-      - flatpak/modules/bclibc.yml
     env:
-      OBJECTBOX_PREBUILT_DIR: /run/build/ebalistyka/objectbox-c
-    extra_sources:
-      - type: archive
-        only-arches:
-          - x86_64
-        url: https://github.com/objectbox/objectbox-c/releases/download/v5.3.2/objectbox-linux-x64.tar.gz
-        sha256: 6dbb5450c36dd11ee9074f16ecc61e79b45ff43c2082934601f3166b39c8a613
-        dest: objectbox-c
-        strip-components: 0
-      - type: archive
-        only-arches:
-          - aarch64
-        url: https://github.com/objectbox/objectbox-c/releases/download/v5.3.2/objectbox-linux-aarch64.tar.gz
-        sha256: bdfbfbf4971057e11018ca6645697d8a40ebc7df56ccde63397cbb0e0609c0e8
-        dest: objectbox-c
-        strip-components: 0
+      OBJECTBOX_PREBUILT_DIR: /app

--- a/test/core/solver/ffi_test.dart
+++ b/test/core/solver/ffi_test.dart
@@ -2,10 +2,10 @@
 //
 // Build the native library first:
 //   make native
-//   dart test test/ffi_test.dart
+//   dart test test/core/solver/ffi_test.dart
 //
 // Or point to a custom build:
-//   BCLIBC_FFI_PATH=/path/to/libbclibc_ffi.so dart test test/ffi_test.dart
+//   BCLIBC_FFI_PATH=/path/to/libbclibc_ffi.so dart test test/core/solver/ffi_test.dart
 
 import 'package:bclibc_ffi/bclibc.dart';
 import 'package:test/test.dart';
@@ -62,43 +62,30 @@ final _g7Table = [
 ];
 
 // ---------------------------------------------------------------------------
-// Standard sea-level atmosphere (ICAO)
-// ---------------------------------------------------------------------------
-
-const _atmo = BcAtmosphere(
-  t0: 15.0, // °C
-  a0: 0.0, // ft (sea level)
-  p0: 1013.25, // hPa
-  mach: 1126.0, // fps (~340 m/s at 15 °C)
-  densityRatio: 1.0,
-  cLowestTempC: -89.2,
-);
-
-const _coriolis = BcCoriolis(); // no coriolis
-
-// ---------------------------------------------------------------------------
 // Typical long-range .338 Lapua Magnum shot
+// ICAO standard sea-level atmosphere: 15 °C, 1013.25 hPa, 0 ft
 // ---------------------------------------------------------------------------
 
-BcShotProps _makeShotProps({
+BcShot _makeShot({
   double barrelElevationRad = 0.0,
-  BCIntegrationMethod method = BCIntegrationMethod.BC_INTEGRATION_RK4,
-}) => BcShotProps(
-  bc: 0.279, // G7 BC
-  lookAngleRad: 0.0,
-  twistInch: 10.0,
-  lengthInch: 1.3,
-  diameterInch: 0.338,
+  BCLIBCFFI_IntegrationMethod method =
+      BCLIBCFFI_IntegrationMethod.BCLIBCFFI_INTEGRATION_RK4,
+}) => BcShot(
+  bc: 0.279,
   weightGrain: 300.0,
-  barrelElevationRad: barrelElevationRad,
-  barrelAzimuthRad: 0.0,
-  sightHeightFt: 0.21 / 3.28084, // 21 cm in feet
-  cantAngleRad: 0.0,
-  alt0Ft: 0.0,
+  diameterInch: 0.338,
+  lengthInch: 1.3,
   muzzleVelocityFps: 2750.0,
-  atmo: _atmo,
-  coriolis: _coriolis,
+  sightHeightFt: 0.21 / 3.28084, // 21 cm in feet
+  twistInch: 10.0,
+  tempC: 15.0,
+  pressureHpa: 1013.25,
+  altitudeFt: 0.0,
+  humidity: 0.0,
   dragTable: _g7Table,
+  lookAngleRad: 0.0,
+  barrelElevationRad: barrelElevationRad,
+  method: method,
 );
 
 void main() {
@@ -142,67 +129,66 @@ void main() {
     });
   });
 
-  // ── findZeroAngle ────────────────────────────────────────────────────────
+  // ── findZeroAngleShot ────────────────────────────────────────────────────
 
-  group('findZeroAngle', () {
+  group('findZeroAngleShot', () {
     test('returns non-zero elevation for 1000 ft zero', () {
-      final props = _makeShotProps();
-      final angle = bc.findZeroAngle(props, 1000.0);
-      // Should be a small upward angle (positive radians)
+      final shot = _makeShot();
+      final angle = bc.findZeroAngleShot(shot, 1000.0);
       expect(angle, greaterThan(0.0));
       expect(angle, lessThan(0.1)); // sanity: < ~5.7°
     });
 
     test('zero angle increases with distance', () {
-      final props = _makeShotProps();
-      final a100 = bc.findZeroAngle(props, 100.0 * 3.28084);
-      final a500 = bc.findZeroAngle(props, 500.0 * 3.28084);
-      final a1000 = bc.findZeroAngle(props, 1000.0 * 3.28084);
+      final shot = _makeShot();
+      final a100 = bc.findZeroAngleShot(shot, 100.0 * 3.28084);
+      final a500 = bc.findZeroAngleShot(shot, 500.0 * 3.28084);
+      final a1000 = bc.findZeroAngleShot(shot, 1000.0 * 3.28084);
       expect(a500, greaterThan(a100));
       expect(a1000, greaterThan(a500));
     });
   });
 
-  // ── findApex ─────────────────────────────────────────────────────────────
+  // ── findApexShot ─────────────────────────────────────────────────────────
 
-  group('findApex', () {
+  group('findApexShot', () {
     test('returns apex above muzzle height', () {
-      // 45° up shot
-      final props = _makeShotProps(barrelElevationRad: 0.785398);
-      final apex = bc.findApex(props);
+      final shot = _makeShot(barrelElevationRad: 0.785398); // 45°
+      final apex = bc.findApexShot(shot);
       expect(apex.heightFt, greaterThan(0.0));
       expect(apex.distanceFt, greaterThan(0.0));
     });
   });
 
-  // ── integrate ────────────────────────────────────────────────────────────
+  // ── integrateShot ────────────────────────────────────────────────────────
 
-  group('integrate', () {
+  group('integrateShot', () {
     test('returns trajectory records with RANGE flag', () {
-      final props = _makeShotProps();
+      final shot = _makeShot();
       final request = BcTrajectoryRequest(
-        rangeLimitFt: 1000.0 * 3.28084, // 1 km
-        rangeStepFt: 100.0 * 3.28084, // every 100 m
-        filterFlags: BCTrajFlag.BC_TRAJ_FLAG_RANGE.value,
+        rangeLimitFt: 1000.0 * 3.28084,
+        rangeStepFt: 100.0 * 3.28084,
+        filterFlags: BCLIBCFFI_TrajFlag.BCLIBCFFI_TRAJ_FLAG_RANGE.value,
       );
-      final result = bc.integrate(props, request);
+      final result = bc.integrateShot(shot, request);
       expect(result.trajectory, isNotEmpty);
-      // All records should carry the RANGE flag
       for (final p in result.trajectory) {
-        expect(p.flag & BCTrajFlag.BC_TRAJ_FLAG_RANGE.value, isNot(0));
+        expect(
+          p.flag & BCLIBCFFI_TrajFlag.BCLIBCFFI_TRAJ_FLAG_RANGE.value,
+          isNot(0),
+        );
       }
     });
 
     test('velocity decreases monotonically', () {
-      final props = _makeShotProps();
+      final shot = _makeShot();
       final request = BcTrajectoryRequest(
         rangeLimitFt: 1000.0 * 3.28084,
         rangeStepFt: 50.0 * 3.28084,
-        filterFlags: BCTrajFlag.BC_TRAJ_FLAG_RANGE.value,
+        filterFlags: BCLIBCFFI_TrajFlag.BCLIBCFFI_TRAJ_FLAG_RANGE.value,
       );
-      final result = bc.integrate(props, request);
+      final result = bc.integrateShot(shot, request);
       expect(result.trajectory.length, greaterThan(1));
-
       for (var i = 1; i < result.trajectory.length; i++) {
         expect(
           result.trajectory[i].velocityFps,
@@ -212,14 +198,13 @@ void main() {
     });
 
     test('distance increases monotonically', () {
-      final props = _makeShotProps();
+      final shot = _makeShot();
       final request = BcTrajectoryRequest(
         rangeLimitFt: 500.0 * 3.28084,
         rangeStepFt: 50.0 * 3.28084,
-        filterFlags: BCTrajFlag.BC_TRAJ_FLAG_RANGE.value,
+        filterFlags: BCLIBCFFI_TrajFlag.BCLIBCFFI_TRAJ_FLAG_RANGE.value,
       );
-      final result = bc.integrate(props, request);
-
+      final result = bc.integrateShot(shot, request);
       for (var i = 1; i < result.trajectory.length; i++) {
         expect(
           result.trajectory[i].distanceFt,
@@ -229,31 +214,30 @@ void main() {
     });
 
     test('EULER method also produces a trajectory', () {
-      final props = _makeShotProps(
-        method: BCIntegrationMethod.BC_INTEGRATION_EULER,
+      final shot = _makeShot(
+        method: BCLIBCFFI_IntegrationMethod.BCLIBCFFI_INTEGRATION_EULER,
       );
       final request = BcTrajectoryRequest(
         rangeLimitFt: 500.0 * 3.28084,
         rangeStepFt: 100.0 * 3.28084,
-        filterFlags: BCTrajFlag.BC_TRAJ_FLAG_RANGE.value,
+        filterFlags: BCLIBCFFI_TrajFlag.BCLIBCFFI_TRAJ_FLAG_RANGE.value,
       );
-      final result = bc.integrate(props, request);
+      final result = bc.integrateShot(shot, request);
       expect(result.trajectory, isNotEmpty);
     });
   });
 
-  // ── integrateAt ──────────────────────────────────────────────────────────
+  // ── integrateAtShot ──────────────────────────────────────────────────────
 
-  group('integrateAt', () {
+  group('integrateAtShot', () {
     test('returns interception at a specific distance', () {
-      final props = _makeShotProps();
+      final shot = _makeShot();
       final targetFt = 500.0 * 3.28084;
-      final intercept = bc.integrateAt(
-        props,
-        BCBaseTrajInterpKey.BC_INTERP_KEY_POS_X, // POS_X = down-range distance
+      final intercept = bc.integrateAtShot(
+        shot,
+        BCLIBCFFI_BaseTrajInterpKey.BCLIBCFFI_INTERP_KEY_POS_X,
         targetFt,
       );
-      // The interception distance should be close to the requested distance
       expect(intercept.fullData.distanceFt, closeTo(targetFt, targetFt * 0.01));
     });
   });


### PR DESCRIPTION
### Changed
- `packages/bclibc_ffi` (`calculator.dart`): `Calculator._toBcShotProps()` replaced with thin field mapper `_toBcShot()` — Coriolis trig (`_toCoriolis`: sin/cos lat/az, range/cross offsets) and atmosphere density (`_toAtmo`) removed from Dart; all physics conversion delegated to `BCLIBC_Shot::to_shot_props()` in C++ (Step 3a of bclibc-wrapper-consolidation)
- `packages/bclibc_ffi` (`bclibc_ffi.dart`): added `BcShot` Dart value class, `_FillNativeShot` extension, and `BcLibC.*Shot()` API methods (`findApexShot`, `findMaxRangeShot`, `findZeroAngleShot`, `integrateShot`, `integrateAtShot`)
- `packages/bclibc_ffi` (`bclibc_bindings.g.dart`): added `BCShot` native struct and `BCLIBCFFI_*_shot` lookup bindings (manually updated; regenerate with `dart run ffigen --config ffigen.yaml` after building bclibc)
- `external/bclibc` submodule bumped to `caf42e0` — adds `BCShot` C struct and `BCLIBCFFI_*_shot()` entry points to `bclibc_ffi.h`; `BcShotProps` / `BCLIBCFFI_*` retained for backwards compatibility; `Vacuum` handled correctly (`pressure_hpa == 0` → zero density, no drag)